### PR TITLE
Bug fixes

### DIFF
--- a/pydrobert/speech/command_line.py
+++ b/pydrobert/speech/command_line.py
@@ -236,7 +236,7 @@ def compute_feats_from_kaldi_tables(args=None):
     postprocessors = []
     try:
         if isinstance(options.postprocess, dict):
-            postproccessors.append(alias_factory_subclass_from_arg(
+            postprocessors.append(alias_factory_subclass_from_arg(
                 PostProcessor, options.postprocess))
         else:
             for element in options.postprocess:

--- a/pydrobert/speech/command_line.py
+++ b/pydrobert/speech/command_line.py
@@ -463,7 +463,7 @@ def signals_to_torch_feat_dir(args=None):
                 PreProcessor, element))
     postprocessors = []
     if isinstance(options.postprocess, dict):
-        postproccessors.append(alias_factory_subclass_from_arg(
+        postprocessors.append(alias_factory_subclass_from_arg(
             PostProcessor, options.postprocess))
     else:
         for element in options.postprocess:

--- a/pydrobert/speech/compute.py
+++ b/pydrobert/speech/compute.py
@@ -241,6 +241,14 @@ class LinearFilterBankFrameComputer(FrameComputer):
         return self._bank.num_filts + int(self._include_energy)
 
 
+def _power(x):
+    return np.linalg.norm(x, ord=2) ** 2
+
+
+def _mag(x):
+    return np.sum(np.abs(x))
+
+
 class ShortTimeFourierTransformFrameComputer(LinearFilterBankFrameComputer):
     """Compute features of a signal by integrating STFTs
 
@@ -360,9 +368,9 @@ class ShortTimeFourierTransformFrameComputer(LinearFilterBankFrameComputer):
         else:
             self._dft_size = self._frame_length
         if self._power:
-            self._nonlin_op = lambda x: np.linalg.norm(x, ord=2) ** 2
+            self._nonlin_op = _power
         else:
-            self._nonlin_op = lambda x: np.sum(np.abs(x))
+            self._nonlin_op = _mag
         self._truncated_filts = []
         self._filt_start_idxs = []
         for filt_idx in range(bank.num_filts):

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -5,11 +5,8 @@ from __future__ import division
 from __future__ import print_function
 
 import os
-import sys
-import warnings
 
 from math import erf
-from tempfile import mkdtemp
 
 import numpy as np
 import pytest


### PR DESCRIPTION
This PR solves the following bugs:

- Lambdas in STFTFeatureComputer could sometimes cause serialization errors. Removed.
- "postprocessors" was misspelled as "postproccessors"
- A check in copy_shorten_samples was incorrectly looking at a constant instead of checking a variable value