### PR TITLE
Fix Gammatone ERB coefficient computations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## HEAD
 
+- Bug fix for issue #14 - Gammatone alpha coefficient wrong for ERB
 - Added `Stack` to `post`
 - Added `soundfile` decoding to `read_signal`.
 - Removed catch-all condition for `read_signal` (when all else fails, try

--- a/src/pydrobert/speech/filters.py
+++ b/src/pydrobert/speech/filters.py
@@ -1015,7 +1015,7 @@ class ComplexGammatoneFilterBank(LinearFilterBank):
         log_factorial = np.log(np.math.factorial(order - 1))
         log_2 = np.log(2)
         if erb:
-            alpha_const = (order - 1) * log_2
+            alpha_const = log_2 * (2 * order - 1)
             alpha_const += 2 * log_factorial
             alpha_const -= log_double_factorial
         else:
@@ -1139,10 +1139,9 @@ class ComplexGammatoneFilterBank(LinearFilterBank):
         else:
             dft_size = width
         res = np.zeros(dft_size, dtype=np.complex128)
+        omega = np.arange(dft_size, dtype=np.float64) * 2 * np.pi / width
         for period in range(left_period, right_period + 1):
-            for idx in range(dft_size):
-                omega = (idx / width + period) * 2 * np.pi
-                res[idx] += self._H(omega, filt_idx)
+            res += self._H(omega + 2 * np.pi * period, filt_idx)
         return res
 
     def get_truncated_response(
@@ -1156,8 +1155,8 @@ class ComplexGammatoneFilterBank(LinearFilterBank):
         # the threshold due to wrapping.
         if right_sup - left_sup + wrap_ang >= 2 * np.pi:
             return 0, self.get_frequency_response(filt_idx, width)
-        left_idx = int(np.ceil(width * left_sup / 2 / np.pi))
-        right_idx = int(width * right_sup / 2 / np.pi)
+        left_idx = int(np.ceil(width * left_sup / (2 * np.pi)))
+        right_idx = int(width * right_sup / (2 * np.pi))
         omega = np.arange(left_idx, right_idx + 1, dtype=np.float64)
         omega *= 2 * np.pi / width
         return left_idx % width, self._H(omega, filt_idx)

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -76,13 +76,11 @@ def test_truncated_matches_full(bank):
         left_samp, right_samp = bank.supports[filt_idx]
         dft_size = int(
             max(
-                (right_samp - left_samp) * (1 + np.random.random()),
+                (right_samp - left_samp),
                 2 * bank.sampling_rate / (right_hz - left_hz),
                 1,
             )
         )
-        left_period = int(np.floor(left_hz / bank.sampling_rate))
-        right_period = int(np.ceil(right_hz / bank.sampling_rate))
         full_response = bank.get_frequency_response(filt_idx, dft_size)
         bin_idx, truncated = bank.get_truncated_response(filt_idx, dft_size)
         challenge = np.zeros(dft_size, dtype=truncated.dtype)
@@ -104,14 +102,12 @@ def test_truncated_matches_full(bank):
             )
         )
         assert np.allclose(
-            full_response,
-            challenge,
-            atol=(right_period - left_period) * EFFECTIVE_SUPPORT_THRESHOLD,
+            full_response, challenge, atol=EFFECTIVE_SUPPORT_THRESHOLD,
         ), "idx: {} threshold:{} full:{} challenge:{}".format(
             filt_idx,
             EFFECTIVE_SUPPORT_THRESHOLD,
-            full_response[bad_idx],
-            challenge[bad_idx],
+            abs(full_response[bad_idx]),
+            abs(challenge[bad_idx]),
         )
 
 


### PR DESCRIPTION
Fixes issue #14. Was computing the ERB coefficient `alpha = 2^(n - 1) (n - 1)! / (2n - 2)!` when it should've been `alpha = 2^(2n - 1) (n - 1)! / (2n - 2)!`