### PR TITLE
v0.3.0 preparation

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,5 +1,4 @@
 version: build.{build}.branch.{branch}
-image: Visual Studio 2019
 
 environment:
   matrix:
@@ -14,6 +13,12 @@ branches:
     - /docs/
 
 for:
+  - 
+    matrix:
+      except:
+        - job_name: dist
+    image: Visual Studio 2019
+
   -
     matrix:
       only:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -17,7 +17,7 @@ for:
     matrix:
       except:
         - job_name: dist
-    image: Visual Studio 2019
+    APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
 
   -
     matrix:
@@ -30,7 +30,7 @@ for:
     matrix:
       only:
         - job_name: dist
-    image: Ubuntu
+    APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu
     stack: python 3.7
     install:
       - python -m pip install build twine wheel

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -31,8 +31,8 @@ for:
     build_script:
       - py -3.7 -m build -o dist
     test_script:
-      - py -3.7 -m twine check (Resolve-Path 'dist\*').Path
-      - py -3.7 -m pip install (Resolve-Path 'dist\*.whl').Path pytest
+      - ps: py -3.7 -m twine check (Resolve-Path 'dist\*').Path
+      - ps: py -3.7 -m pip install (Resolve-Path 'dist\*.whl').Path pytest
       - py -3.7 -m pytest
     artifacts:
       path: 'dist\*'

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -31,6 +31,7 @@ for:
     build_script:
       - py -3.7 -m build -o dist
     test_script:
+      - py -3.7 -m twine check (Resolve-Path 'dist\*').Path
       - py -3.7 -m pip install (Resolve-Path 'dist\*.whl').Path pytest
       - py -3.7 -m pytest
     artifacts:
@@ -44,4 +45,3 @@ install:
 
 test_script:
   - py -3.7 -m tox
-

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,48 +1,24 @@
 version: build.{build}.branch.{branch}
+image: Visual Studio 2019
 
 environment:
   matrix:
-    # - TOXENV: py37
-    # - TOXENV: py38
-    # - TOXENV: py39
-    # - TOXENV: py310
-    - job_name: dist
+    - TOXENV: py37
+    - TOXENV: py38
+    - TOXENV: py39
+    - TOXENV: py310
 
 branches:
   except:
     - /docs/
 
 for:
-  - 
-    matrix:
-      except:
-        - job_name: dist
-    APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
-
   -
     matrix:
       only:
         - TOXENV: "py38"
         - TOXENV: "py39"
     skip_non_tags: true
-  
-  -
-    matrix:
-      only:
-        - job_name: dist
-    APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu
-    stack: python 3.7
-    install:
-      - python -m pip install build twine wheel
-    build: script
-    build_script:
-      - python -m build -o dist
-    test_script:
-      - python -m twine check dist/*
-      - python -m pip install dist/*.whl pytest
-      - python -m pytest
-    artifacts:
-      path: 'dist\*'
 
 build: off
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -3,10 +3,10 @@ image: Visual Studio 2019
 
 environment:
   matrix:
-    # - TOXENV: py37
-    # - TOXENV: py38
-    # - TOXENV: py39
-    # - TOXENV: py310
+    - TOXENV: py37
+    - TOXENV: py38
+    - TOXENV: py39
+    - TOXENV: py310
     - job_name: dist
 
 branches:
@@ -27,6 +27,7 @@ for:
     matrix:
       only:
         - job_name: dist
+    skip_non_tags: true
     install:
       - python -m pip install -U pip build twine wheel
     build: script

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -26,6 +26,7 @@ for:
     matrix:
       only:
         - job_name: dist
+    skip_non_tags: true
     stack: python 3.7
     install:
       - python -m pip install -U pip build twine wheel

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -25,16 +25,16 @@ for:
     matrix:
       only:
         - job_name: dist
-      install:
-        - py -3.7 -m pip install build twine
-      build: script
-      build_script:
-        - py -3.7 -m build -o dist
-      test_script:
-        - py -3.7 -m pip install (Resolve-Path 'dist\*.whl').Path pytest
-        - py -3.7 -m pytest
-      artifacts:
-        path: 'dist\*'
+    install:
+      - py -3.7 -m pip install build twine
+    build: script
+    build_script:
+      - py -3.7 -m build -o dist
+    test_script:
+      - py -3.7 -m pip install (Resolve-Path 'dist\*.whl').Path pytest
+      - py -3.7 -m pytest
+    artifacts:
+      path: 'dist\*'
 
 build: off
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -21,7 +21,8 @@ for:
         - TOXENV: "py39"
     skip_non_tags: true
   
-  - matrix:
+  -
+    matrix:
       only:
         - job_name: dist
       install:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -3,14 +3,17 @@ image: Visual Studio 2019
 
 environment:
   matrix:
-    - TOXENV: py37
-    - TOXENV: py38
-    - TOXENV: py39
-    - TOXENV: py310
+    # - TOXENV: py37
+    # - TOXENV: py38
+    # - TOXENV: py39
+    # - TOXENV: py310
+    - job_name: dist
 
 branches:
   except:
     - /docs/
+
+stack: python 3.7
 
 for:
   -
@@ -19,12 +22,28 @@ for:
         - TOXENV: "py38"
         - TOXENV: "py39"
     skip_non_tags: true
+  
+  -
+    matrix:
+      only:
+        - job_name: dist
+    install:
+      - python -m pip install -U pip build twine wheel
+    build: script
+    build_script:
+      - python -m build -o dist
+    test_script:
+      - ps: python -m twine check (Resolve-Path 'dist\*').Path
+      - ps: python -m pip install (Resolve-Path 'dist\*.whl').Path pytest
+      - python -m pytest
+    artifacts:
+      path: 'dist\*'
 
 build: off
 
 install:
-  - py -3.7 -m pip install -U pip wheel setuptools
-  - py -3.7 -m pip install -U tox
+  - python -m pip install -U pip wheel setuptools
+  - python -m pip install -U tox
 
 test_script:
-  - py -3.7 -m tox
+  - python -m tox

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -13,7 +13,6 @@ branches:
   except:
     - /docs/
 
-stack: python 3.7
 
 for:
   -
@@ -27,7 +26,7 @@ for:
     matrix:
       only:
         - job_name: dist
-    skip_non_tags: true
+    stack: python 3.7
     install:
       - python -m pip install -U pip build twine wheel
     build: script
@@ -43,8 +42,8 @@ for:
 build: off
 
 install:
-  - python -m pip install -U pip wheel setuptools
-  - python -m pip install -U tox
+  - py -3.7 -m pip install -U pip wheel setuptools
+  - py -3.7 -m pip install -U tox
 
 test_script:
-  - python -m tox
+  - py -3.7 -m tox

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -25,15 +25,17 @@ for:
     matrix:
       only:
         - job_name: dist
+    image: Ubuntu
+    stack: python 3.7
     install:
-      - py -3.7 -m pip install build twine wheel
+      - python -m pip install build twine wheel
     build: script
     build_script:
-      - py -3.7 -m build -o dist
+      - python -m build -o dist
     test_script:
-      - ps: py -3.7 -m twine check (Resolve-Path 'dist\*').Path
-      - ps: py -3.7 -m pip install (Resolve-Path 'dist\*.whl').Path pytest
-      - py -3.7 -m pytest
+      - python -m twine check dist/*
+      - python -m pip install dist/*.whl pytest
+      - python -m pytest
     artifacts:
       path: 'dist\*'
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -26,7 +26,7 @@ for:
       only:
         - job_name: dist
     install:
-      - py -3.7 -m pip install build twine
+      - py -3.7 -m pip install build twine wheel
     build: script
     build_script:
       - py -3.7 -m build -o dist

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -3,11 +3,11 @@ image: Visual Studio 2019
 
 environment:
   matrix:
-    - TOXENV: py37
-    - TOXENV: py38
-    - TOXENV: py39
-    - TOXENV: py310
-
+    # - TOXENV: py37
+    # - TOXENV: py38
+    # - TOXENV: py39
+    # - TOXENV: py310
+    - job_name: dist
 
 branches:
   except:
@@ -20,6 +20,20 @@ for:
         - TOXENV: "py38"
         - TOXENV: "py39"
     skip_non_tags: true
+  
+  - matrix:
+      only:
+        - job_name: dist
+      install:
+        - py -3.7 -m pip install build twine
+      build: script
+      build_script:
+        - py -3.7 -m build -o dist
+      test_script:
+        - py -3.7 -m pip install (Resolve-Path 'dist\*.whl').Path pytest
+        - py -3.7 -m pytest
+      artifacts:
+        path: 'dist\*'
 
 build: off
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## v0.3.0
 
+- Moved `AliasedFactory` and `alias_factory_subclass_from_arg` to `alias`
+  submodule.
 - Removed Python 3.6 support.
 - Bug fix for issue #14 - Gammatone alpha coefficient wrong for ERB.
 - Added `Stack` to `post`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 # Change Log
 
-## HEAD
+## v0.3.0
 
-- Removed Python 3.6 support
-- Bug fix for issue #14 - Gammatone alpha coefficient wrong for ERB
-- Added `Stack` to `post`
+- Removed Python 3.6 support.
+- Bug fix for issue #14 - Gammatone alpha coefficient wrong for ERB.
+- Added `Stack` to `post`.
 - Added `soundfile` decoding to `read_signal`.
 - Removed catch-all condition for `read_signal` (when all else fails, try
   Kaldi and then `numpy.fromfile`). Breaks v0.2.0 behaviour. Needed for

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 prune extras
 exclude .appveyor.yml
+exclude .gitignore

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 prune extras
+exclude .appveyor.yml

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
+# pydrobert-speech
+
 [![Documentation Status](https://readthedocs.org/projects/pydrobert-speech/badge/?version=latest)](https://pydrobert-speech.readthedocs.io/en/latest/?badge=latest)
 [![Build status](https://ci.appveyor.com/api/projects/status/abn39mww84fydxqe/branch/master?svg=true)](https://ci.appveyor.com/project/sdrobert/pydrobert-speech/branch/master)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
-
-# pydrobert-speech
 
 This pure-python library allows for flexible computation of speech features.
 
@@ -50,7 +50,7 @@ to use it.
 
 ## Installation
 
-_pydrobert-speech_ is available via both PyPI and Conda.
+*pydrobert-speech* is available via both PyPI and Conda.
 
 ``` sh
 conda install -c sdrobert pydrobert-speech

--- a/README.md
+++ b/README.md
@@ -46,7 +46,6 @@ to use it.
 ## Documentation
 
 - [Latest](https://pydrobert-speech.readthedocs.io/en/latest/)
-- [Stable](https://pydrobert-speech.readthedocs.io/en/stable/)
 
 ## Installation
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,4 @@
 Sphinx>=4
 sphinxcontrib-programoutput
+sphinx-autodoc-typehints
 myst-parser

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,5 @@
-Sphinx>=4
+Sphinx>=4.4
 sphinxcontrib-programoutput
 sphinx-autodoc-typehints
 myst-parser
+sphinx_rtd_theme>=0.5

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -19,12 +19,8 @@ sys.path.insert(0, os.path.abspath("../../src"))
 # -- Project information -----------------------------------------------------
 
 project = "pydrobert-speech"
-copyright = "2021, Sean Robertson"
+copyright = "2022, Sean Robertson"
 author = "Sean Robertson"
-
-# The full version, including alpha/beta/rc tags
-release = ""
-
 language = "en"
 
 
@@ -34,23 +30,25 @@ language = "en"
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
+    "myst_parser",
     "sphinx.ext.autodoc",
     "sphinx.ext.autosectionlabel",
     "sphinx.ext.intersphinx",
     "sphinx.ext.napoleon",
     "sphinx.ext.viewcode",
     "sphinxcontrib.programoutput",
-    "myst_parser",
+    "sphinx_autodoc_typehints",
 ]
 
 naploeon_numpy_docstring = True
 
 intersphinx_mapping = {
-    "python": ("https://docs.python.org/", None),
-    "numpy": ("https://docs.scipy.org/doc/numpy/", None),
     "matplotlib": ("https://matplotlib.org", None),
+    "numpy": ("https://docs.scipy.org/doc/numpy/", None),
     "pydrobert.kaldi": ("https://pydrobert-kaldi.readthedocs.io/en/latest", None),
+    "python": ("https://docs.python.org/", None),
     "soundfile": ("https://python-soundfile.readthedocs.io/en/latest/", None),
+    "torch": ("https://pytorch.org/docs/stable/", None),
 }
 
 # Add any paths that contain templates here, relative to this directory.
@@ -61,7 +59,16 @@ templates_path = ["_templates"]
 # This pattern also affects html_static_path and html_extra_path.
 exclude_patterns = []
 
-autodoc_mock_imports = ["numpy", "matplotlib"]
+napoleon_numpy_docstring = True
+napoleon_google_docstring = False
+napoleon_include_init_with_doc = True
+autodoc_mock_imports = [
+    "numpy",
+    "matplotlib.axes",
+    "matplotlib.colors",
+    "matplotlib.figure",
+    "matplotlib",
+]
 autodoc_typehints = "none"
 autodoc_inherit_docstrings = False
 # autodoc_preserve_defaults = True

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -70,12 +70,10 @@ autodoc_mock_imports = [
     "matplotlib",
 ]
 autodoc_typehints = "none"
+autodoc_type_aliases = napoleon_type_aliases = {"np.ndarray": "numpy.ndarray"}
 autodoc_inherit_docstrings = False
-# autodoc_preserve_defaults = True
 napoleon_preprocess_types = True
-# napoleon_use_param = True
 typehints_document_rtype = False
-# typehints_defaults = "comma"  # when this works consistently, uncomment!
 napoleon_use_rtype = False
 
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -15,7 +15,6 @@ import sys
 
 sys.path.insert(0, os.path.abspath("../../src"))
 
-autodoc_mock_imports = ["numpy", "matplotlib"]
 
 # -- Project information -----------------------------------------------------
 
@@ -62,15 +61,19 @@ templates_path = ["_templates"]
 # This pattern also affects html_static_path and html_extra_path.
 exclude_patterns = []
 
+autodoc_mock_imports = ["numpy", "matplotlib"]
+autodoc_typehints = "none"
+autodoc_inherit_docstrings = False
+# autodoc_preserve_defaults = True
+napoleon_preprocess_types = True
+# napoleon_use_param = True
+typehints_document_rtype = False
+# typehints_defaults = "comma"  # when this works consistently, uncomment!
+napoleon_use_rtype = False
+
 
 # -- Options for HTML output -------------------------------------------------
-
-on_rtd = os.environ.get("READTHEDOCS") == "True"
-if on_rtd:
-    html_theme = "default"
-else:
-    html_theme = "sphinx_rtd_theme"
-
+html_theme = "sphinx_rtd_theme"
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,

--- a/docs/source/modules.rst
+++ b/docs/source/modules.rst
@@ -3,13 +3,13 @@ pydrobert.speech API
 
 .. automodule:: pydrobert.speech
     :members:
-    :undoc-members:
     :show-inheritance:
 
 .. toctree::
    :maxdepth: 2
    :caption: Submodules:
 
+   pydrobert.speech.alias
    pydrobert.speech.compute
    pydrobert.speech.config
    pydrobert.speech.corpus

--- a/docs/source/overview.rst
+++ b/docs/source/overview.rst
@@ -17,26 +17,27 @@ latter two operators exist in the submodules :mod:`pydrobert.speech.pre` and
 A computer, which can be found in :mod:`pydrobert.speech.compute`, will require
 more complicated initialization. The standard feature representation, which is
 a 2D time-log-frequency matrix of energy, derives from
-:class:`LinearFilterBankFrameComputer`. It calculates coefficients over
-uniform time slices (frames) using a bank of filters. Children of
-:class:`LinearFilterBankFrameComputer` all have similar representations and all
-use linear banks of filters, but can be computed in different ways. The classic
-method of computation is the
-:class:`compute.ShortTimeFourierTransformFrameComputer`.
+:class:`pydrobert.speech.compute.LinearFilterBankFrameComputer`. It calculates
+coefficients over uniform time slices (frames) using a bank of filters.
+Children of :class:`pydrobert.speech.compute.LinearFilterBankFrameComputer` all
+have similar representations and all use linear banks of filters, but can be
+computed in different ways. The classic method of computation is the
+:class:`pydrobert.speech.compute.ShortTimeFourierTransformFrameComputer`.
 
 Banks of filters are derived from
 :class:`pydrobert.speech.filters.LinearFilterBank`. Children of the parent
-class, such as :class:`ComplexGammatoneFilterBank`, will decide on the shape of
-the filters.
+class, such as :class:`pydrobert.speech.filters.ComplexGammatoneFilterBank`,
+will decide on the shape of the filters.
 
-:class:`LinearFilterBankFrameComputer` instances compute coefficients at
-uniform intervals in time. However, the distribution over frequencies is
-decided by the distribution of filter frequency responses from the filter bank,
-which, in turn, depends on a scaling function. Scaling functions can be found
-in :mod:`pydrobert.speech.scales` such as :class:`MelScaling`. Scaling
-functions transform the frequency domain into some other real domain. In *that*
-domain, filter frequency bandwidths are distributed uniformly which, when
-translated back to the frequency domain, could be quite non-uniform.
+:class:`pydrobert.speech.compute.LinearFilterBankFrameComputer` instances
+compute coefficients at uniform intervals in time. However, the distribution
+over frequencies is decided by the distribution of filter frequency responses
+from the filter bank, which, in turn, depends on a scaling function. Scaling
+functions can be found in :mod:`pydrobert.speech.scales` such as
+:class:`pydrobert.speech.scales.MelScaling`. Scaling functions transform the
+frequency domain into some other real domain. In *that* domain, filter
+frequency bandwidths are distributed uniformly which, when translated back to
+the frequency domain, could be quite non-uniform.
 
 In sum, you build a computer by first choosing a scale from
 :mod:`pydrobert.speech.scales`. You then pass that as an argument to a filter

--- a/docs/source/pydrobert.speech.alias.rst
+++ b/docs/source/pydrobert.speech.alias.rst
@@ -1,0 +1,6 @@
+pydrobert.speech.alias
+======================
+
+.. automodule:: pydrobert.speech.alias
+    :members:
+    :show-inheritance:

--- a/docs/source/pydrobert.speech.compute.rst
+++ b/docs/source/pydrobert.speech.compute.rst
@@ -3,5 +3,4 @@ pydrobert.speech.compute
 
 .. automodule:: pydrobert.speech.compute
     :members:
-    :undoc-members:
     :show-inheritance:

--- a/docs/source/pydrobert.speech.config.rst
+++ b/docs/source/pydrobert.speech.config.rst
@@ -3,5 +3,4 @@ pydrobert.speech.config
 
 .. automodule:: pydrobert.speech.config
     :members:
-    :undoc-members:
     :show-inheritance:

--- a/docs/source/pydrobert.speech.corpus.rst
+++ b/docs/source/pydrobert.speech.corpus.rst
@@ -3,5 +3,4 @@ pydrobert.speech.corpus
 
 .. automodule:: pydrobert.speech.corpus
     :members:
-    :undoc-members:
     :show-inheritance:

--- a/docs/source/pydrobert.speech.filters.rst
+++ b/docs/source/pydrobert.speech.filters.rst
@@ -3,5 +3,4 @@ pydrobert.speech.filters
 
 .. automodule:: pydrobert.speech.filters
     :members:
-    :undoc-members:
     :show-inheritance:

--- a/docs/source/pydrobert.speech.post.rst
+++ b/docs/source/pydrobert.speech.post.rst
@@ -3,5 +3,4 @@ pydrobert.speech.post
 
 .. automodule:: pydrobert.speech.post
     :members:
-    :undoc-members:
     :show-inheritance:

--- a/docs/source/pydrobert.speech.pre.rst
+++ b/docs/source/pydrobert.speech.pre.rst
@@ -3,5 +3,4 @@ pydrobert.speech.pre
 
 .. automodule:: pydrobert.speech.pre
     :members:
-    :undoc-members:
     :show-inheritance:

--- a/docs/source/pydrobert.speech.scales.rst
+++ b/docs/source/pydrobert.speech.scales.rst
@@ -3,5 +3,4 @@ pydrobert.speech.scales
 
 .. automodule:: pydrobert.speech.scales
     :members:
-    :undoc-members:
     :show-inheritance:

--- a/docs/source/pydrobert.speech.util.rst
+++ b/docs/source/pydrobert.speech.util.rst
@@ -3,5 +3,4 @@ pydrobert.speech.util
 
 .. automodule:: pydrobert.speech.util
     :members:
-    :undoc-members:
     :show-inheritance:

--- a/docs/source/pydrobert.speech.vis.rst
+++ b/docs/source/pydrobert.speech.vis.rst
@@ -3,5 +3,4 @@ pydrobert.speech.vis
 
 .. automodule:: pydrobert.speech.vis
     :members:
-    :undoc-members:
     :show-inheritance:

--- a/docs/source/references.rst
+++ b/docs/source/references.rst
@@ -14,7 +14,7 @@ References
    Biological Cybernetics, vol. 39, no. 3, pp. 195-209, Jan. 1981.
 .. [oshaughnessy1987] D. O'Shaughnessy, Speech communication: human and
    machine. Addison-Wesley Pub. Co., 1987.
-.. [tranmuller1990] H. Traunmüller, "Analytical expressions for the
+.. [traunmuller1990] H. Traunmüller, "Analytical expressions for the
    tonotopic sensory scale," The Journal of the Acoustical Society of America,
    vol. 88, no. 1, pp. 97-100, Jul. 1990.
 .. [povey2011] D. Povey et al., "The Kaldi Speech Recognition Toolkit," in

--- a/docs/source/references.rst
+++ b/docs/source/references.rst
@@ -14,7 +14,7 @@ References
    Biological Cybernetics, vol. 39, no. 3, pp. 195-209, Jan. 1981.
 .. [oshaughnessy1987] D. O'Shaughnessy, Speech communication: human and
    machine. Addison-Wesley Pub. Co., 1987.
-.. [tranmuller1990] H. Traunm\\:{u}ller, "Analytical expressions for the
+.. [tranmuller1990] H. Traunmüller, "Analytical expressions for the
    tonotopic sensory scale," The Journal of the Acoustical Society of America,
    vol. 88, no. 1, pp. 97-100, Jul. 1990.
 .. [povey2011] D. Povey et al., "The Kaldi Speech Recognition Toolkit," in

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,7 +4,9 @@ description = "Utilities for the python package 'param'"
 long_description = file: README.md
 long_description_content_type = text/markdown
 license = Apache-2.0
-license_file = LICENSE
+license_files =
+  LICENSE
+  LICENSE_sph2pipe
 url = https://github.com/sdrobert/pydrobert-speech
 project_urls =
   Documentation = https://pydrobert-speech.readthedocs.io

--- a/src/pydrobert/speech/__init__.py
+++ b/src/pydrobert/speech/__init__.py
@@ -33,7 +33,6 @@ __all__ = [
     "pre",
     "scales",
     "util",
-    "vis",
 ]
 
 

--- a/src/pydrobert/speech/__init__.py
+++ b/src/pydrobert/speech/__init__.py
@@ -14,7 +14,9 @@
 
 """Speech processing library"""
 
-import abc
+import warnings
+
+from .alias import AliasedFactory as _AF
 
 __author__ = "Sean Robertson"
 __email__ = "sdrobert@cs.toronto.edu"
@@ -22,48 +24,33 @@ __license__ = "Apache 2.0"
 __copyright__ = "Copyright 2021 Sean Robertson"
 
 __all__ = [
-    "AliasedFactory",
+    "alias",
+    "compute",
+    "config",
+    "corpus",
+    "filters",
+    "post",
+    "pre",
+    "scales",
+    "util",
+    "vis",
 ]
+
+
+class AliasedFactory(_AF):
+    @classmethod
+    def from_alias(cls, alias: str, *args, **kwargs):
+        warnings.warn(
+            "using AliasedFactory from pydrobert.speech is deprecated. Import from "
+            "pydrobert.speech.alias",
+            category=DeprecationWarning,
+            stacklevel=2,
+        )
+        return super().from_alias(alias, *args, **kwargs)
+
 
 try:
     from ._version import version as __version__  # type: ignore
 except ImportError:
     __version__ = "inplace"
 
-
-class AliasedFactory(abc.ABC):
-    """An abstract interface for initialing concrete subclasses with aliases"""
-
-    aliases = set()
-
-    @classmethod
-    def from_alias(cls, alias: str, *args, **kwargs):
-        """Factory method for initializing a subclass that goes by an alias
-
-        All subclasses of this class have the class attribute ``aliases``. This
-        method matches `alias` to an element in some subclass' ``aliases`` and
-        initializes it. Aliases of this class are included in the search. Alias
-        conflicts are resolved by always trying to initialize the last
-        registered subclass that matches the alias.
-
-        Parameters
-        ----------
-        alias : str
-
-        Raises
-        ------
-        ValueError
-            Alias can't be found
-        """
-        stack = [cls]
-        pushed_children = set()
-        while stack:
-            parent = stack.pop()
-            if parent not in pushed_children:
-                children = parent.__subclasses__()
-                stack.append(parent)
-                stack.extend(children)
-                pushed_children.add(parent)
-            elif alias in parent.aliases:
-                return parent(*args, **kwargs)
-        raise ValueError('Cannot find subclass with alias "{}"'.format(alias))

--- a/src/pydrobert/speech/alias.py
+++ b/src/pydrobert/speech/alias.py
@@ -15,28 +15,40 @@
 """Functionality to do with alias factories"""
 
 import abc
-from typing import Mapping, Type, Union
+from typing import Any, Mapping, Set, Type, TypeVar, Union, Type
 
 __all__ = [
     "alias_factory_subclass_from_arg",
     "AliasedFactory",
 ]
 
+T = TypeVar("T", bound="AliasedFactory", covariant=True)
+
 
 class AliasedFactory(abc.ABC):
     """An abstract interface for initialing concrete subclasses with aliases"""
 
-    aliases = set()
+    aliases: Set[str] = set()
+    """class aliases for :func:`from_alias`"""
 
     @classmethod
-    def from_alias(cls, alias: str, *args, **kwargs):
+    def from_alias(cls: Type[T], alias: str, *args, **kwargs) -> T:
         """Factory method for initializing a subclass that goes by an alias
 
-        All subclasses of this class have the class attribute ``aliases``. This method
-        matches `alias` to an element in some subclass' ``aliases`` and initializes it.
+        All subclasses of this class have the class attribute `aliases`. This method
+        matches `alias` to an element in some subclass' `aliases` and initializes it.
         Aliases of this class are included in the search. Alias conflicts are resolved
         by always trying to initialize the last registered subclass that matches the
         alias.
+
+        Parameters
+        ----------
+        alias
+            Alias of the subclass
+        *args
+            Positional arguments to initialize the subclass
+        **kwargs
+            Keyword arguments to initialize the subclass
 
         Raises
         ------
@@ -58,8 +70,8 @@ class AliasedFactory(abc.ABC):
 
 
 def alias_factory_subclass_from_arg(
-    factory_class: Type[AliasedFactory], arg: Union[AliasedFactory, str, Mapping]
-) -> AliasedFactory:
+    factory_class: Type[T], arg: Union[T, str, Mapping[str, Any]]
+) -> T:
     """Boilerplate for getting an instance of an AliasedFactory
 
     Rather than an instance itself, a function could receive the arguments to initialize

--- a/src/pydrobert/speech/alias.py
+++ b/src/pydrobert/speech/alias.py
@@ -1,0 +1,88 @@
+# Copyright 2022 Sean Robertson
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Functionality to do with alias factories"""
+
+import abc
+from typing import Mapping, Type, Union
+
+__all__ = [
+    "alias_factory_subclass_from_arg",
+    "AliasedFactory",
+]
+
+
+class AliasedFactory(abc.ABC):
+    """An abstract interface for initialing concrete subclasses with aliases"""
+
+    aliases = set()
+
+    @classmethod
+    def from_alias(cls, alias: str, *args, **kwargs):
+        """Factory method for initializing a subclass that goes by an alias
+
+        All subclasses of this class have the class attribute ``aliases``. This method
+        matches `alias` to an element in some subclass' ``aliases`` and initializes it.
+        Aliases of this class are included in the search. Alias conflicts are resolved
+        by always trying to initialize the last registered subclass that matches the
+        alias.
+
+        Raises
+        ------
+        ValueError
+            Alias can't be found
+        """
+        stack = [cls]
+        pushed_children = set()
+        while stack:
+            parent = stack.pop()
+            if parent not in pushed_children:
+                children = parent.__subclasses__()
+                stack.append(parent)
+                stack.extend(children)
+                pushed_children.add(parent)
+            elif alias in parent.aliases:
+                return parent(*args, **kwargs)
+        raise ValueError(f"Cannot find subclass with alias '{alias}'")
+
+
+def alias_factory_subclass_from_arg(
+    factory_class: Type[AliasedFactory], arg: Union[AliasedFactory, str, Mapping]
+) -> AliasedFactory:
+    """Boilerplate for getting an instance of an AliasedFactory
+
+    Rather than an instance itself, a function could receive the arguments to initialize
+    an :class:`AliasedFactory` with :func:`AliasedFactory.from_alias`. This function
+    uses the following strategy to try and do so
+
+    1. If `arg` is an instance of `factory_class`, return `arg`
+    2. If `arg` is a :class:`str`, use it as the alias
+    3. a. Copy `arg` to a dictionary
+       b. Pop the key :obj:`'alias'` and treat the rest as keyword arguments
+       c. If the key :obj:`'alias'` is not found, try :obj:`'name'`
+
+    This function is intentionally limited in order to work nicely with JSON config
+    files.
+    """
+    if isinstance(arg, factory_class):
+        return arg
+    elif isinstance(arg, str):
+        return factory_class.from_alias(arg)
+    else:
+        arg = dict(arg)
+        try:
+            alias = arg.pop("alias")
+        except KeyError:
+            alias = arg.pop("name")
+        return factory_class.from_alias(alias, **arg)

--- a/src/pydrobert/speech/command_line.py
+++ b/src/pydrobert/speech/command_line.py
@@ -30,7 +30,7 @@ import pydrobert.speech.config as config
 from pydrobert.speech.compute import FrameComputer
 from pydrobert.speech.pre import PreProcessor
 from pydrobert.speech.post import PostProcessor
-from pydrobert.speech.util import alias_factory_subclass_from_arg
+from pydrobert.speech.alias import alias_factory_subclass_from_arg
 from pydrobert.speech.util import read_signal
 
 try:

--- a/src/pydrobert/speech/compute.py
+++ b/src/pydrobert/speech/compute.py
@@ -129,7 +129,7 @@ class FrameComputer(AliasedFactory):
 
         Parameters
         ----------
-        chunk : array-like
+        chunk
             A 1D float array of the signal. Should be contiguous and non-overlapping
             with any previously processed segments in the audio stream
 

--- a/src/pydrobert/speech/compute.py
+++ b/src/pydrobert/speech/compute.py
@@ -27,22 +27,21 @@ except ImportError:
 
 import numpy as np
 
-from pydrobert.speech import AliasedFactory
+from pydrobert.speech.alias import AliasedFactory, alias_factory_subclass_from_arg
 from pydrobert.speech import config
 from pydrobert.speech.filters import GammaWindow
 from pydrobert.speech.filters import HannWindow
 from pydrobert.speech.filters import LinearFilterBank
 from pydrobert.speech.filters import WindowFunction
-from pydrobert.speech.util import alias_factory_subclass_from_arg
 
 __all__ = [
+    "frame_by_frame_calculation",
     "FrameComputer",
     "LinearFilterBankFrameComputer",
-    "ShortTimeFourierTransformFrameComputer",
-    "STFTFrameComputer",
     "ShortIntegrationFrameComputer",
+    "ShortTimeFourierTransformFrameComputer",
     "SIFrameComputer",
-    "frame_by_frame_calculation",
+    "STFTFrameComputer",
 ]
 
 
@@ -76,12 +75,12 @@ class FrameComputer(AliasedFactory):
     def frame_style(self) -> Literal["causal", "centered"]:
         """Dictates how the signal is split into frames
 
-        If :obj:`'causal'`, the k-th frame is computed over the indices ``signal[k
-        * frame_shift:k * frame_shift + frame_length]`` (at most). If
-        :obj:`'centered'`, the k-th frame is computed over the indices ``signal[k
-        * frame_shift - (frame_length + 1) // 2 + 1:k * frame_shift +
-        frame_length // 2 + 1]``. Any range beyond the bounds of the signal is
-        generated in an implementation-specific way.
+        If :obj:`'causal'`, the k-th frame is computed over the indices ``signal[k *
+        frame_shift:k * frame_shift + frame_length]`` (at most). If :obj:`'centered'`,
+        the k-th frame is computed over the indices ``signal[k * frame_shift -
+        (frame_length + 1) // 2 + 1:k * frame_shift + frame_length // 2 + 1]``. Any
+        range beyond the bounds of the signal is generated in an implementation-specific
+        way.
         """
         pass
 
@@ -131,9 +130,8 @@ class FrameComputer(AliasedFactory):
         Parameters
         ----------
         chunk : array-like
-            A 1D float array of the signal. Should be contiguous and
-            non-overlapping with any previously processed segments in
-            the audio stream
+            A 1D float array of the signal. Should be contiguous and non-overlapping
+            with any previously processed segments in the audio stream
 
         Returns
         -------
@@ -151,8 +149,8 @@ class FrameComputer(AliasedFactory):
         Returns
         -------
         chunk : np.ndarray
-            A 2D float array of shape ``(num_frames, num_coeffs)``.
-            ``num_frames`` is either 1 or 0.
+            A 2D float array of shape ``(num_frames, num_coeffs)``. ``num_frames`` is
+            either 1 or 0.
         """
         pass
 
@@ -161,21 +159,21 @@ class FrameComputer(AliasedFactory):
 
         Parameters
         ----------
-        signal : array-like
+        signal
             A 1D float array of the entire signal
 
         Returns
         -------
         spec : np.ndarray
-            A 2D float array of shape ``(num_frames, num_coeffs)``.
-            ``num_frames`` is nonnegative (possibly 0). Contains some
-            number of feature vectors, ordered in time over axis 0.
+            A 2D float array of shape ``(num_frames, num_coeffs)``. ``num_frames`` is
+            nonnegative (possibly 0). Contains some number of feature vectors, ordered
+            in time over axis 0.
 
         Raises
         ------
         ValueError
-            If already begin computing frames (``started=True``), and
-            :func:`finalize` has not been called
+            If already begin computing frames (``started=True``), and :func:`finalize`
+            has not been called
         """
         return frame_by_frame_calculation(self, signal)
 
@@ -190,14 +188,13 @@ class LinearFilterBankFrameComputer(FrameComputer):
 
     Parameters
     ----------
-    bank : pydrobert.speech.filters.LinearFilterBank, dict, or str
-        Each filter in the bank corresponds to a coefficient in a
-        frame vector. Can be a :class:`LinearFilterBank` or something compatible
-        with :func:`pydrobert.speech.alias_factory_subclass_from_arg`
-    include_energy : bool, optional
-        Whether to include a coefficient based on the energy of the
-        signal within the frame. If :obj:`True`, the energy coefficient
-        will be inserted at index 0.
+    bank
+        Each filter in the bank corresponds to a coefficient in a frame vector. Can be a
+        :class:`LinearFilterBank` or something compatible with
+        :func:`pydrobert.speech.alias_factory_subclass_from_arg`
+    include_energy
+        Whether to include a coefficient based on the energy of the signal within the
+        frame. If :obj:`True`, the energy coefficient will be inserted at index 0.
     """
 
     def __init__(
@@ -254,29 +251,29 @@ class ShortTimeFourierTransformFrameComputer(LinearFilterBankFrameComputer):
 
     Parameters
     ----------
-    bank : LinearFilterBank or dict or str
-    frame_length_ms : float, optional
+    bank
+    frame_length_ms
         The length of a frame, in milliseconds. Defaults to the length of the largest
         filter in the bank
     frame_shift_ms : float, optional
         The offset between successive frames, in milliseconds
-    frame_style : {'causal', 'centered'}, optional
+    frame_style
         Defaults to :obj:`'centered'` if ``bank.is_zero_phase``, :obj:`'causal'`
         otherwise.
-    include_energy : bool, optional
-    pad_to_nearest_power_of_two : bool, optional
+    include_energy
+    pad_to_nearest_power_of_two
         Whether the DFT should be a padded to a power of two for computational
         efficiency
-    window_function : pydrobert.speech.filters.WindowFunction, dict, or str
+    window_function
         The window used in step 1. Can be a :class:`WindowFunction` or something
         compatible with :func:`pydrobert.speech.alias_factory_subclass_from_arg`.
         Defaults to :class:`pydrobert.speech.filters.GammaWindow` when `frame_style` is
         :obj:`'causal'`, otherwise :class:`pydrobert.speech.filters.HannWindow`.
-    use_log : bool, optional
+    use_log
         Whether to take the log of the sum from 3b.
-    use_power : bool, optional
+    use_power
         Whether to sum the power spectrum or the magnitude spectrum
-    kaldi_shift : bool, optional
+    kaldi_shift
         If :obj:`True`, the k-th frame will be computed using the signal between
         ``signal[ k - frame_length // 2 + frame_shift // 2:k + (frame_length + 1) // 2
         + frame_shift // 2]``. These are the frame bounds for Kaldi [povey2011]_.
@@ -289,7 +286,7 @@ class ShortTimeFourierTransformFrameComputer(LinearFilterBankFrameComputer):
         bank: Union[LinearFilterBank, Mapping, str],
         frame_length_ms: Optional[float] = None,
         frame_shift_ms: Optional[float] = 10,
-        frame_style: Optional[str] = None,
+        frame_style: Optional[Literal["causal", "centered"]] = None,
         include_energy: bool = False,
         pad_to_nearest_power_of_two: bool = True,
         window_function: Optional[Union[WindowFunction, Mapping, str]] = None,
@@ -625,16 +622,16 @@ class ShortIntegrationFrameComputer(LinearFilterBankFrameComputer):
 
     Parameters
     ----------
-    bank : pydrobert.speech.filters.LinearFilterBank or dict or str
-    frame_shift_ms : float, optional
+    bank
+    frame_shift_ms
         The offset between successive frames, in milliseconds. Also the length of the
         integration
-    frame_style : {'causal', 'centered'}, optional
+    frame_style
         Defaults to :obj:`'centered'` if `bank.is_zero_phase`, :obj:`'causal'`
         otherwise. If :obj:`'centered'` each filter of the bank is translated so that
         its support lies in the center of the frame
-    include_energy : bool, optional
-    pad_to_nearest_power_of_two : bool, optional
+    include_energy
+    pad_to_nearest_power_of_two
         Pad the DFTs used in computation to a power of two for efficient computation
     window_function : pydrobert.speech.filters.WindowFunction, dict, or str
         The window used to weigh integration. Can be a :class:`WindowFunction` or
@@ -642,9 +639,9 @@ class ShortIntegrationFrameComputer(LinearFilterBankFrameComputer):
         :func:`pydrobert.speech.alias_factory_subclass_from_arg`. Defaults to
         :class:`pydrobert.speech.filters.GammaWindow` when ``frame_style`` is
         :obj:`'causal'`, otherwise :class:`pydrobert.speech.filters.HannWindow`.
-    use_power : bool, optional
+    use_power
         Whether the pointwise linearity is the signal's power or magnitude
-    use_log : bool, optional
+    use_log
         Whether to take the log of the integration
     """
 
@@ -654,10 +651,10 @@ class ShortIntegrationFrameComputer(LinearFilterBankFrameComputer):
         self,
         bank: Union[LinearFilterBank, Mapping, str],
         frame_shift_ms: float = 10,
-        frame_style: Optional[str] = None,
+        frame_style: Optional[Literal["causal", "centered"]] = None,
         include_energy: bool = False,
         pad_to_nearest_power_of_two: bool = True,
-        window_function: Union[WindowFunction, Mapping, str] = None,
+        window_function: Optional[Union[WindowFunction, Mapping, str]] = None,
         use_power: bool = False,
         use_log: bool = True,
     ):
@@ -1006,15 +1003,15 @@ def frame_by_frame_calculation(
 
     Parameters
     ----------
-    computer : FrameComputer
-    signal : array-like
+    computer
+    signal
         A 1D float array of the entire signal
-    chunk_size : int
+    chunk_size
         The length of the signal buffer to process at a given time
 
     Returns
     -------
-    spec : array-like
+    spec : np.ndarray
         A 2D float array of shape ``(num_frames, num_coeffs)``. ``num_frames`` is
         nonnegative (possibly 0). Contains some number of feature vectors, ordered in
         time over axis 0.

--- a/src/pydrobert/speech/compute.py
+++ b/src/pydrobert/speech/compute.py
@@ -73,7 +73,7 @@ class FrameComputer(AliasedFactory):
 
     @abc.abstractproperty
     def frame_style(self) -> Literal["causal", "centered"]:
-        """Dictates how the signal is split into frames
+        """str : Dictates how the signal is split into frames
 
         If :obj:`'causal'`, the k-th frame is computed over the indices ``signal[k *
         frame_shift:k * frame_shift + frame_length]`` (at most). If :obj:`'centered'`,
@@ -86,37 +86,37 @@ class FrameComputer(AliasedFactory):
 
     @abc.abstractproperty
     def sampling_rate(self) -> float:
-        """Number of samples in a second of a target recording"""
+        """float : Number of samples in a second of a target recording"""
         pass
 
     @abc.abstractproperty
     def frame_length(self) -> int:
-        """Number of samples which dictate a feature vector"""
+        """int : Number of samples which dictate a feature vector"""
         pass
 
     @property
     def frame_length_ms(self) -> float:
-        """Number of milliseconds of audio which dictate a feature vector"""
+        """float : Number of milliseconds of audio which dictate a feature vector"""
         return self.frame_length * 1000 / self.sampling_rate
 
     @abc.abstractproperty
     def frame_shift(self) -> int:
-        """Number of samples absorbed between successive frame computations"""
+        """int : Number of samples absorbed between successive frame computations"""
         pass
 
     @property
     def frame_shift_ms(self) -> float:
-        """Number of milliseconds between succecssive frame computations"""
+        """float : Number of milliseconds between succecssive frame computations"""
         return self.frame_shift * 1000 / self.sampling_rate
 
     @abc.abstractproperty
     def num_coeffs(self) -> int:
-        """Number of coefficients returned per frame"""
+        """int : Number of coefficients returned per frame"""
         pass
 
     @abc.abstractproperty
     def started(self) -> bool:
-        """Whether computations for a signal have started
+        """bool : Whether computations for a signal have started
 
         Becomes :obj:`True` after the first call to :func:`compute_chunk`. Becomes
         :obj:`False` after call to :func:`finalize`
@@ -191,7 +191,7 @@ class LinearFilterBankFrameComputer(FrameComputer):
     bank
         Each filter in the bank corresponds to a coefficient in a frame vector. Can be a
         :class:`LinearFilterBank` or something compatible with
-        :func:`pydrobert.speech.alias_factory_subclass_from_arg`
+        :func:`pydrobert.speech.alias.alias_factory_subclass_from_arg`
     include_energy
         Whether to include a coefficient based on the energy of the signal within the
         frame. If :obj:`True`, the energy coefficient will be inserted at index 0.
@@ -205,12 +205,12 @@ class LinearFilterBankFrameComputer(FrameComputer):
 
     @property
     def bank(self) -> LinearFilterBank:
-        """The LinearFilterBank from which features are derived"""
+        """LinearFilterBank : The LinearFilterBank from which features are derived"""
         return self._bank
 
     @property
     def includes_energy(self) -> bool:
-        """Whether the first coefficient is an energy coefficient"""
+        """bool : Whether the first coefficient is an energy coefficient"""
         return self._include_energy
 
     @property
@@ -252,6 +252,9 @@ class ShortTimeFourierTransformFrameComputer(LinearFilterBankFrameComputer):
     Parameters
     ----------
     bank
+        Each filter in the bank corresponds to a coefficient in a frame vector. Can be a
+        :class:`LinearFilterBank` or something compatible with
+        :func:`pydrobert.speech.alias.alias_factory_subclass_from_arg`
     frame_length_ms
         The length of a frame, in milliseconds. Defaults to the length of the largest
         filter in the bank
@@ -279,7 +282,7 @@ class ShortTimeFourierTransformFrameComputer(LinearFilterBankFrameComputer):
         + frame_shift // 2]``. These are the frame bounds for Kaldi [povey2011]_.
     """
 
-    aliases = {"stft"}
+    aliases = {"stft"}  #:
 
     def __init__(
         self,
@@ -623,6 +626,9 @@ class ShortIntegrationFrameComputer(LinearFilterBankFrameComputer):
     Parameters
     ----------
     bank
+        Each filter in the bank corresponds to a coefficient in a frame vector. Can be a
+        :class:`LinearFilterBank` or something compatible with
+        :func:`pydrobert.speech.alias.alias_factory_subclass_from_arg`
     frame_shift_ms
         The offset between successive frames, in milliseconds. Also the length of the
         integration
@@ -645,7 +651,7 @@ class ShortIntegrationFrameComputer(LinearFilterBankFrameComputer):
         Whether to take the log of the integration
     """
 
-    aliases = {"si"}
+    aliases = {"si"}  #:
 
     def __init__(
         self,

--- a/src/pydrobert/speech/config.py
+++ b/src/pydrobert/speech/config.py
@@ -16,6 +16,13 @@
 
 from typing import Set
 
+__all__ = [
+    "EFFECTIVE_SUPPORT_THRESHOLD",
+    "LOG_FLOOR_VALUE",
+    "SOUNDFILE_SUPPORTED_TYPES",
+    "USE_FFTPACK",
+]
+
 
 USE_FFTPACK = False
 """
@@ -47,7 +54,7 @@ LOG_FLOOR_VALUE = 1e-5
 _BASE_SOUNDFILE_SUPPORTED_TYPES = {"wav", "ogg", "flac", "aiff"}
 _FULL_SOUNDFILE_SUPPORTED_TYPES: Set[str] = set()
 
-SOUNDFILE_SUPPORTED_FILE_TYPES: Set[str] = set()
+SOUNDFILE_SUPPORTED_FILE_TYPES: Set[str] = set()  #: :meta hide-value:
 f"""
 A list of the types of files SoundFile will be responsible for reading. If
 :mod:`soundfile` can be imported, it's the intersection of

--- a/src/pydrobert/speech/corpus.py
+++ b/src/pydrobert/speech/corpus.py
@@ -18,7 +18,7 @@
 from itertools import cycle
 
 from pydrobert.speech.post import PostProcessor
-from pydrobert.speech.util import alias_factory_subclass_from_arg
+from pydrobert.speech.alias import alias_factory_subclass_from_arg
 
 
 __all__ = ["post_process_wrapper"]

--- a/src/pydrobert/speech/corpus.py
+++ b/src/pydrobert/speech/corpus.py
@@ -16,6 +16,7 @@
 
 
 from itertools import cycle
+from typing import TypeVar, Type
 
 from pydrobert.speech.post import PostProcessor
 from pydrobert.speech.alias import alias_factory_subclass_from_arg
@@ -23,8 +24,10 @@ from pydrobert.speech.alias import alias_factory_subclass_from_arg
 
 __all__ = ["post_process_wrapper"]
 
+T = TypeVar("T", covariant=True)
 
-def post_process_wrapper(cls: type) -> type:
+
+def post_process_wrapper(cls: Type[T]) -> Type[T]:
     """Wrap a pydrobert-kaldi Data object for post-processing
 
     This function returns a class that wraps the `cls` class, performing some

--- a/src/pydrobert/speech/filters.py
+++ b/src/pydrobert/speech/filters.py
@@ -54,12 +54,12 @@ class LinearFilterBank(AliasedFactory):
 
     @abc.abstractproperty
     def is_real(self) -> bool:
-        """Whether the filters are real or complex"""
+        """bool : Whether the filters are real or complex"""
         pass
 
     @abc.abstractproperty
     def is_analytic(self) -> bool:
-        """Whether the filters are (approximately) analytic
+        """bool : Whether the filters are (approximately) analytic
         
         An analytic signal has no negative frequency components. A real signal cannot
         be analytic.
@@ -68,7 +68,7 @@ class LinearFilterBank(AliasedFactory):
 
     @abc.abstractproperty
     def is_zero_phase(self) -> bool:
-        """Whether the filters are zero phase or not
+        """bool : Whether the filters are zero phase or not
 
         Zero phase filters are even functions with no imaginary part in the fourier
         domain. Their impulse responses center around 0.
@@ -77,17 +77,17 @@ class LinearFilterBank(AliasedFactory):
 
     @abc.abstractproperty
     def num_filts(self) -> int:
-        """Number of filters in the bank"""
+        """int : Number of filters in the bank"""
         pass
 
     @abc.abstractproperty
     def sampling_rate(self) -> float:
-        """Number of samples in a second of a target recording"""
+        """float : Number of samples in a second of a target recording"""
         pass
 
     @abc.abstractproperty
     def supports_hz(self) -> Tuple[Tuple[float, float], ...]:
-        """Boundaries of effective support of filter freq responses, in Hz.
+        """tuple : Boundaries of effective support of filter freq responses, in Hz.
 
         Returns a tuple of length `num_filts` containing pairs of floats of the low and
         high frequencies. Frequencies outside the span have a response of approximately
@@ -109,7 +109,7 @@ class LinearFilterBank(AliasedFactory):
 
     @abc.abstractproperty
     def supports(self) -> Tuple[Tuple[float, float], ...]:
-        """Boundaries of effective support of filter impulse resps, in samples
+        """tuple : Boundaries of effective support of filter impulse resps, in samples
 
         Returns a tuple of length `num_filts` containing pairs of integers of the first
         and last (effectively) nonzero samples.
@@ -128,7 +128,7 @@ class LinearFilterBank(AliasedFactory):
 
     @property
     def supports_ms(self) -> Tuple[Tuple[float, float], ...]:
-        """Boundaries of effective support of filter impulse resps, in ms"""
+        """tuple : Boundaries of effective support of filter impulse resps, in ms"""
         return tuple(
             (s[0] * 1000 / self.sampling_rate, s[1] * 1000 / self.sampling_rate,)
             for s in self.supports
@@ -247,7 +247,7 @@ class TriangularOverlappingFilterBank(LinearFilterBank):
     scaling_function
         Dictates the layout of filters in the Fourier domain. Can be a
         :class:`ScalingFunction` or something compatible with
-        :func:`pydrobert.speech.alias_factory_subclass_from_arg`
+        :func:`pydrobert.speech.alias.alias_factory_subclass_from_arg`
     num_filts
         The number of filters in the bank
     high_hz
@@ -270,7 +270,7 @@ class TriangularOverlappingFilterBank(LinearFilterBank):
         ``high_hz <= low_hz``
     """
 
-    aliases = {"tri", "triangular"}
+    aliases = {"tri", "triangular"}  #:
 
     def __init__(
         self,
@@ -471,7 +471,7 @@ class Fbank(LinearFilterBank):
     square root of the frequency response.
     """
 
-    aliases = {"fbank"}
+    aliases = {"fbank"}  #:
 
     def __init__(
         self,
@@ -523,7 +523,7 @@ class Fbank(LinearFilterBank):
 
     @property
     def centers_hz(self) -> Tuple[float, ...]:
-        """The point of maximum gain in each filter's frequency response, in Hz
+        """tuple : The point of maximum gain in each filter's frequency response, in Hz
 
         This property gives the so-called "center frequencies" - the point of maximum
         gain - of each filter.
@@ -658,7 +658,7 @@ class GaborFilterBank(LinearFilterBank):
     scaling_function
         Dictates the layout of filters in the Fourier domain. Can be a
         :class:`ScalingFunction` or something compatible with
-        :func:`pydrobert.speech.alias_factory_subclass_from_arg`
+        :func:`pydrobert.speech.alias.alias_factory_subclass_from_arg`
     num_filts
         The number of filters in the bank
     high_hz
@@ -679,7 +679,7 @@ class GaborFilterBank(LinearFilterBank):
         The absolute value below which counts as zero
     """
 
-    aliases = {"gabor"}
+    aliases = {"gabor"}  #:
 
     def __init__(
         self,
@@ -794,7 +794,7 @@ class GaborFilterBank(LinearFilterBank):
 
     @property
     def centers_hz(self) -> Tuple[float, ...]:
-        """The point of maximum gain in each filter's frequency response, in Hz
+        """tuple :The point of maximum gain in each filter's frequency response, in Hz
 
         This property gives the so-called "center frequencies" - the
         point of maximum gain - of each filter.
@@ -931,7 +931,7 @@ class ComplexGammatoneFilterBank(LinearFilterBank):
     scaling_function
         Dictates the layout of filters in the Fourier domain. Can be a
         :class:`ScalingFunction` or something compatible with
-        :func:`pydrobert.speech.alias_factory_subclass_from_arg`
+        :func:`pydrobert.speech.alias.alias_factory_subclass_from_arg`
     num_filts
         The number of filters in the bank
     high_hz
@@ -958,7 +958,7 @@ class ComplexGammatoneFilterBank(LinearFilterBank):
         The absolute value below which counts as zero
     """
 
-    aliases = {"gammatone", "tonebank"}
+    aliases = {"gammatone", "tonebank"}  #:
 
     def __init__(
         self,
@@ -1087,7 +1087,7 @@ class ComplexGammatoneFilterBank(LinearFilterBank):
 
     @property
     def centers_hz(self) -> Tuple[float, ...]:
-        """The point of maximum gain in each filter's frequency response, in Hz
+        """int : The point of maximum gain in each filter's frequency response, in Hz
 
         This property gives the so-called "center frequencies" - the point of maximum
         gain - of each filter.
@@ -1239,7 +1239,7 @@ class BartlettWindow(WindowFunction):
     numpy.bartlett
     """
 
-    aliases = {"bartlett", "triangular", "tri"}
+    aliases = {"bartlett", "triangular", "tri"}  #:
 
     def get_impulse_response(self, width: int) -> np.ndarray:
         window = np.bartlett(width)
@@ -1255,7 +1255,7 @@ class BlackmanWindow(WindowFunction):
     numpy.blackman
     """
 
-    aliases = {"blackman", "black"}
+    aliases = {"blackman", "black"}  #:
 
     def get_impulse_response(self, width: int) -> np.ndarray:
         window = np.blackman(width)
@@ -1271,7 +1271,7 @@ class HammingWindow(WindowFunction):
     numpy.hamming
     """
 
-    aliases = {"hamming"}
+    aliases = {"hamming"}  #:
 
     def get_impulse_response(self, width: int) -> np.ndarray:
         window = np.hamming(width)
@@ -1287,7 +1287,7 @@ class HannWindow(WindowFunction):
     numpy.hanning
     """
 
-    aliases = {"hanning", "hann"}
+    aliases = {"hanning", "hann"}  #:
 
     def get_impulse_response(self, width: int) -> np.ndarray:
         window = np.hanning(width)
@@ -1318,9 +1318,9 @@ class GammaWindow(WindowFunction):
         where the approximate maximal value of the window lies
     """
 
-    order : int
-    peak : int
-    aliases = {"gamma"}
+    order: int  #:
+    peak: float  #:
+    aliases = {"gamma"}  #:
 
     def __init__(self, order: int = 4, peak: float = 0.75):
         self.order = order

--- a/src/pydrobert/speech/filters.py
+++ b/src/pydrobert/speech/filters.py
@@ -20,25 +20,25 @@ from typing import Mapping, Optional, Tuple, Union
 
 import numpy as np
 
-from pydrobert.speech import AliasedFactory
-from pydrobert.speech import config
+import pydrobert.speech.config as config
+
+from pydrobert.speech.alias import AliasedFactory, alias_factory_subclass_from_arg
 from pydrobert.speech.scales import MelScaling
 from pydrobert.speech.scales import ScalingFunction
-from pydrobert.speech.util import alias_factory_subclass_from_arg
 from pydrobert.speech.util import angular_to_hertz
 from pydrobert.speech.util import hertz_to_angular
 
 __all__ = [
-    "LinearFilterBank",
-    "TriangularOverlappingFilterBank",
-    "GaborFilterBank",
-    "ComplexGammatoneFilterBank",
-    "WindowFunction",
     "BartlettWindow",
     "BlackmanWindow",
+    "ComplexGammatoneFilterBank",
+    "GaborFilterBank",
+    "GammaWindow",
     "HammingWindow",
     "HannWindow",
-    "GammaWindow",
+    "LinearFilterBank",
+    "TriangularOverlappingFilterBank",
+    "WindowFunction",
 ]
 
 # banks
@@ -142,9 +142,9 @@ class LinearFilterBank(AliasedFactory):
 
         Parameters
         ----------
-        filt_idx : int
+        filt_idx
             The index of the filter to generate. Less than `num_filts`
-        width : int
+        width
             The length of the buffer, in samples. If less than the support of the
             filter, the filter will alias.
 
@@ -167,11 +167,11 @@ class LinearFilterBank(AliasedFactory):
 
         Parameters
         ----------
-        filt_idx : int
+        filt_idx
             The index of the filter to generate. Less than `num_filts`
-        width : int
+        width
             The length of the DFT to output
-        half : bool, optional
+        half
             Whether to return only the DFT bins between ``[0,pi]``
 
         Results
@@ -223,9 +223,9 @@ class LinearFilterBank(AliasedFactory):
 
         Parameters
         ----------
-        filt_idx : int
+        filt_idx
             The index of the filter to generate. Less than `num_filts`
-        width : int
+        width
             The length of the DFT to output
 
         Returns
@@ -244,22 +244,23 @@ class TriangularOverlappingFilterBank(LinearFilterBank):
 
     Parameters
     ----------
-    scaling_function : pydrobert.speech.scales.ScalingFunction, str, or dict
+    scaling_function
         Dictates the layout of filters in the Fourier domain. Can be a
         :class:`ScalingFunction` or something compatible with
         :func:`pydrobert.speech.alias_factory_subclass_from_arg`
-    num_filts : int, optional
+    num_filts
         The number of filters in the bank
-    high_hz, low_hz : float, optional
-        The topmost and bottommost edge of the filters, respectively. The default for
-        `high_hz` is the Nyquist
-    sampling_rate : float, optional
+    high_hz
+        The topmost edge of the filter frequencies. The default is the Nyquist for
+        `sampling_rate`.
+    low_hz
+        The bottommost edge of the filter frequences.
+    sampling_rate
         The sampling rate (cycles/sec) of the target recordings
-    analytic : bool, optional
+    analytic
         Whether to use an analytic form of the bank. The analytic form is easily derived
         from the real form in [povey2011]_ and [young]_. Since the filter is compactly
         supported in frequency, the analytic form is simply the suppression of the
-
         ``[-pi, 0)`` frequencies
 
     Raises
@@ -447,29 +448,20 @@ class Fbank(LinearFilterBank):
 
     Parameters
     ----------
-    num_filts : int, optional
+    num_filts
         The number of filters in the bank
-    high_hz, low_hz : float, optional
-        The topmost and bottommost edge of the filters, respectively. The default for
-        high_hz is the Nyquist
-    sampling_rate : float, optional
+    high_hz
+        The topmost edge of the filter frequencies. The default is the Nyquist for
+        `sampling_rate`.
+    low_hz
+        The bottommost edge of the filter frequences.
+    sampling_rate 
         The sampling rate (cycles/sec) of the target recordings
-    analytic : bool, optional
+    analytic
         Whether to use an analytic form of the bank. The analytic form is easily derived
         from the real form in [povey2011]_ and [young]_. Since the filter is compactly
         supported in frequency, the analytic form is simply the suppression of the
         ``[-pi, 0)`` frequencies
-
-    Attributes
-    ----------
-    centers_hz : tuple
-    is_real : bool
-    is_analytic : bool
-    num_filts : int
-    sampling_rate : float
-    supports_hz : tuple
-    supports : tuple
-    supports_ms : tuple
 
     Notes
     -----
@@ -663,18 +655,20 @@ class GaborFilterBank(LinearFilterBank):
 
     Parameters
     ----------
-    scaling_function : pydrobert.speech.ScalingFunction, str, or dict
+    scaling_function
         Dictates the layout of filters in the Fourier domain. Can be a
         :class:`ScalingFunction` or something compatible with
         :func:`pydrobert.speech.alias_factory_subclass_from_arg`
-    num_filts : int
+    num_filts
         The number of filters in the bank
-    high_hz, low_hz : float, optional
-        The topmost and bottommost edge of the filters, respectively. The default for
-        `high_hz` is the Nyquist
-    sampling_rate : float, optional
+    high_hz
+        The topmost edge of the filter frequencies. The default is the Nyquist for
+        `sampling_rate`.
+    low_hz
+        The bottommost edge of the filter frequences.
+    sampling_rate
         The sampling rate (cycles/sec) of the target recordings
-    scale_l2_norm : bool
+    scale_l2_norm
         Whether to scale the l2 norm of each filter to 1. Otherwise the frequency
         response of each filter will max out at an absolute value of 1.
     erb : bool
@@ -934,27 +928,29 @@ class ComplexGammatoneFilterBank(LinearFilterBank):
 
     Parameters
     ----------
-    scaling_function : pydrobert.speech.ScalingFunction, str, or dict
+    scaling_function
         Dictates the layout of filters in the Fourier domain. Can be a
         :class:`ScalingFunction` or something compatible with
         :func:`pydrobert.speech.alias_factory_subclass_from_arg`
-    num_filts : int, optional
+    num_filts
         The number of filters in the bank
-    high_hz, low_hz : float, optional
-        The topmost and bottommost edge of the filters, respectively. The default for
-        high_hz is the Nyquist
+    high_hz
+        The topmost edge of the filter frequencies. The default is the Nyquist for
+        `sampling_rate`.
+    low_hz
+        The bottommost edge of the filter frequences.
     sampling_rate : float, optional
         The sampling rate (cycles/sec) of the target recordings
-    order : int, optional
+    order
         The :math:`n` parameter in the Gammatone. Should be positive. Larger orders
         will make the gammatone more symmetrical.
-    max_centered : bool, optional
+    max_centered
         While normally causal, setting `max_centered` to true will shift all filters in
         the bank such that the maximum absolute value in time is centered at sample 0.
-    scale_l2_norm : bool
+    scale_l2_norm
         Whether to scale the l2 norm of each filter to 1. Otherwise the frequency
         response of each filter will max out at an absolute value of 1.
-    erb : bool
+    erb
 
     See Also
     --------
@@ -1224,7 +1220,7 @@ class WindowFunction(AliasedFactory):
         
         Parameters
         ----------
-        width : int
+        width
             The length of the window in samples
         
         Returns
@@ -1316,17 +1312,14 @@ class GammaWindow(WindowFunction):
 
     Arguments
     ---------
-    order : int
-    peak : float
+    order
+    peak
         ``peak * width``, where ``width`` is the length of the window in samples, is
         where the approximate maximal value of the window lies
-
-    Attributes
-    ----------
-    order : int
-    peak : float
     """
 
+    order : int
+    peak : int
     aliases = {"gamma"}
 
     def __init__(self, order: int = 4, peak: float = 0.75):

--- a/src/pydrobert/speech/filters.py
+++ b/src/pydrobert/speech/filters.py
@@ -174,7 +174,7 @@ class LinearFilterBank(AliasedFactory):
         half
             Whether to return only the DFT bins between ``[0,pi]``
 
-        Results
+        Returns
         -------
         fr : np.ndarray
             If `half` is :obj:`False`, returns a 1D float64 or complex128 numpy array of
@@ -913,7 +913,7 @@ class ComplexGammatoneFilterBank(LinearFilterBank):
 
     .. math::
 
-        H(\omega) = \frac{c(n - 1)!)}{\left(
+        H(\omega) = \frac{c(n - 1)!}{\left(
             \alpha + i(\omega - \xi) \right)^n}
 
     For large :math:`\xi`, the complex gammatone is approximately analytic.

--- a/src/pydrobert/speech/post.py
+++ b/src/pydrobert/speech/post.py
@@ -82,6 +82,7 @@ class Standardize(PostProcessor):
     ----------
     rfilename
     norm_var
+    **kwargs
 
     Notes
     -----
@@ -94,7 +95,7 @@ class Standardize(PostProcessor):
         Describes the strategy used for loading signals
     """
 
-    aliases = {"standardize", "normalize", "unit", "cmvn"}
+    aliases = {"standardize", "normalize", "unit", "cmvn"}  #:
 
     def __init__(
         self, rfilename: Optional[str] = None, norm_var: bool = True, **kwargs
@@ -153,7 +154,7 @@ class Standardize(PostProcessor):
 
     @property
     def have_stats(self) -> bool:
-        """Whether at least one feature vector has been accumulated"""
+        """bool : Whether at least one feature vector has been accumulated"""
         return self._stats is not None and self._stats[0, -1]
 
     def _accumulate_vector(self, vec):
@@ -426,15 +427,16 @@ class Deltas(PostProcessor):
     target_axis
     concatenate
     context_window
-        The length of the filter to either side of the window. Positive
+        The length of the filter to either side of the window. Positive.
     pad_mode
-        How to pad the input sequence when correlating. Additional keyword arguments
-        will be passed to :func:`numpy.pad`
+        How to pad the input sequence when correlating
+    **kwargs
+        Additional keyword arguments to be passed to :func:`numpy.pad`
     """
 
-    aliases = {"deltas"}
-    concatenate: bool
-    num_deltas: int
+    aliases = {"deltas"}  #:
+    concatenate: bool  #:
+    num_deltas: int  #:
 
     def __init__(
         self,
@@ -505,10 +507,9 @@ class Stack(PostProcessor):
         be divisible by `num_vectors`.
     """
 
-    aliases = {"stack"}
-
-    num_vectors: int
-    time_axis: int
+    aliases = {"stack"}  #:
+    num_vectors: int  #:
+    time_axis: int  #:
 
     def __init__(
         self,

--- a/src/pydrobert/speech/post.py
+++ b/src/pydrobert/speech/post.py
@@ -23,7 +23,7 @@ from itertools import count
 
 import numpy as np
 
-from pydrobert.speech import AliasedFactory
+from pydrobert.speech.alias import AliasedFactory
 from pydrobert.speech.util import read_signal
 
 __all__ = [
@@ -48,12 +48,12 @@ class PostProcessor(AliasedFactory):
 
         Parameters
         ----------
-        features : array-like
-        axis : int, optional
+        features
+        axis
             The axis of `features` to apply the transformation along
-        in_place : bool, optional
-            Whether it is okay to modify features (:obj:`True`) or whether
-            a copy should be made (:obj:`False`)
+        in_place
+            Whether it is okay to modify features (:obj:`True`) or whether a copy should
+            be made (:obj:`False`)
 
         Returns
         -------
@@ -80,8 +80,8 @@ class Standardize(PostProcessor):
 
     Parameters
     ----------
-    rfilename : str, optional
-    norm_var : bool, optional
+    rfilename
+    norm_var
 
     Notes
     -----
@@ -96,7 +96,9 @@ class Standardize(PostProcessor):
 
     aliases = {"standardize", "normalize", "unit", "cmvn"}
 
-    def __init__(self, rfilename: str = None, norm_var: bool = True, **kwargs):
+    def __init__(
+        self, rfilename: Optional[str] = None, norm_var: bool = True, **kwargs
+    ):
         self._stats = None
         self._norm_var = bool(norm_var)
         if rfilename is not None:
@@ -192,12 +194,11 @@ class Standardize(PostProcessor):
 
         Parameters
         ----------
-        features : array-like
-        axis : int, optional
+        features
+        axis
 
         Raises
         ------
-        IndexError
         ValueError
             If the length of `axis` does not match that of past feature
             vector lengths
@@ -325,10 +326,10 @@ class Standardize(PostProcessor):
 
         Parameters
         ----------
-        wfilename : str
-        key : str, optional
-        compress : bool
-        overwrite : bool
+        wfilename
+        key
+        compress
+        overwrite
 
         Raises
         ------
@@ -421,22 +422,19 @@ class Deltas(PostProcessor):
 
     Parameters
     ----------
-    num_deltas : int
-    target_axis : int, optional
-    concatenate : bool
-    context_window : int, optional
+    num_deltas
+    target_axis
+    concatenate
+    context_window
         The length of the filter to either side of the window. Positive
-    pad_mode : str or function, optional
+    pad_mode
         How to pad the input sequence when correlating. Additional keyword arguments
         will be passed to :func:`numpy.pad`
-
-    Attributes
-    ----------
-    num_deltas : int
-    concatenate : bool
     """
 
     aliases = {"deltas"}
+    concatenate: bool
+    num_deltas: int
 
     def __init__(
         self,
@@ -496,21 +494,15 @@ class Stack(PostProcessor):
 
     Parameters
     ----------
-    num_vectors : int
+    num_vectors
         The number of subsequent feature vectors in time to be stacked.
-    time_axis : int, optional
+    time_axis
         The axis along which subsequent feature vectors are drawn.
-    pad_mode : str or function or None, optional
+    pad_mode
         Specified how the axis in time will be padded on the right in order to be
         divisible by `num_vectors`. Additional keyword arguments will be passed to
         :func:`numpy.pad`. If unspecified, frames will instead be discarded in order to
         be divisible by `num_vectors`.
-    
-    Attributes
-    ----------
-    num_vectors : int
-    time_axis : int
-    pad_mode : str or function or None
     """
 
     aliases = {"stack"}

--- a/src/pydrobert/speech/post.py
+++ b/src/pydrobert/speech/post.py
@@ -406,7 +406,7 @@ class Deltas(PostProcessor):
 
     where
 
-    .. math:: Z = \sum_t f(t) ** 2
+    .. math:: Z = \sum_t f(t)^2
 
     for some :math:`W \geq 1`. Its Fourier Transform is
 

--- a/src/pydrobert/speech/pre.py
+++ b/src/pydrobert/speech/pre.py
@@ -20,7 +20,7 @@ from typing import Optional
 
 import numpy as np
 
-from pydrobert.speech import AliasedFactory
+from pydrobert.speech.alias import AliasedFactory
 
 __all__ = [
     "PreProcessor",
@@ -40,16 +40,16 @@ class PreProcessor(AliasedFactory):
 
         Parameters
         ----------
-        signal : array-like
-        axis : int, optional
+        signal
+        axis
             The axis of `signal` to apply the transformation along
-        in_place : bool, optional
+        in_place
             Whether it is okay to modify `signal` (:obj:`True`) or whether a copy should
             be made (:obj:`False`)
 
         Returns
         -------
-        out : array-like
+        out : np.ndarray
             The transformed features
         """
         pass
@@ -67,14 +67,11 @@ class Dither(PreProcessor):
 
     Parameters
     ----------
-    coeff : float
+    coeff
         Added noise will be in the range ``[-coeff, coeff]``
-
-    Attributes
-    ----------
-    coeff : float
     """
 
+    coeff: float
     aliases = {"dither", "dithering"}
 
     def __init__(self, coeff: float = 1.0):
@@ -114,13 +111,10 @@ class Preemphasize(PreProcessor):
 
     Parameters
     ----------
-    coeff : float
-
-    Attributes
-    ----------
-    coeff : float
+    coeff
     """
 
+    coeff: float
     aliases = {"preemphasize", "preemphasis", "preemph"}
 
     def __init__(self, coeff: float = 0.97):

--- a/src/pydrobert/speech/pre.py
+++ b/src/pydrobert/speech/pre.py
@@ -71,12 +71,12 @@ class Dither(PreProcessor):
         Added noise will be in the range ``[-coeff, coeff]``
     """
 
-    coeff: float
-    aliases = {"dither", "dithering"}
+    coeff: float  #:
+    aliases = {"dither", "dithering"}  #:
 
     def __init__(self, coeff: float = 1.0):
+        super().__init__()
         self.coeff = coeff
-        super(Dither, self).__init__()
 
     def apply(
         self, signal: np.ndarray, axis: Optional[int] = None, in_place: bool = False
@@ -114,12 +114,12 @@ class Preemphasize(PreProcessor):
     coeff
     """
 
-    coeff: float
-    aliases = {"preemphasize", "preemphasis", "preemph"}
+    coeff: float  #:
+    aliases = {"preemphasize", "preemphasis", "preemph"}  #:
 
     def __init__(self, coeff: float = 0.97):
+        super().__init__()
         self.coeff = coeff
-        super(Preemphasize, self).__init__()
 
     def apply(
         self, signal: np.ndarray, axis: int = -1, in_place: bool = False

--- a/src/pydrobert/speech/scales.py
+++ b/src/pydrobert/speech/scales.py
@@ -61,9 +61,9 @@ class LinearScaling(ScalingFunction):
         The increase in scale corresponding to a 1 Hertz increase in frequency.
     """
 
-    low_hz: float
-    slop_hz: float
-    aliases = {"linear", "uniform"}
+    low_hz: float  #:
+    slop_hz: float  #:
+    aliases = {"linear", "uniform"}  #:
 
     def __init__(self, low_hz: float, slope_hz: float = 1.0):
         self.low_hz = low_hz
@@ -84,15 +84,10 @@ class OctaveScaling(ScalingFunction):
     low_hz
         The positive frequency (in Hertz) corresponding to scale 0. Frequencies below
         this value should never be queried.
-
-    Raises
-    ------
-    ValueError
-        If `low_hz` is non-positive
     """
 
-    low_hz: float
-    aliases = {"octave"}
+    low_hz: float  #:
+    aliases = {"octave"}  #:
 
     def __init__(self, low_hz: float):
         if low_hz <= 0:
@@ -121,7 +116,7 @@ class MelScaling(ScalingFunction):
     Where :math:`s` is the scale and :math:`f` is the frequency in Hertz.
     """
 
-    aliases = {"mel"}
+    aliases = {"mel"}  #:
 
     def scale_to_hertz(self, scale: float) -> float:
         return 700.0 * (np.exp(scale / 1127.0) - 1.0)
@@ -154,7 +149,7 @@ class BarkScaling(ScalingFunction):
     Where :math:`s` is the scale and :math:`f` is the frequency in Hertz.
     """
 
-    aliases = {"bark"}
+    aliases = {"bark"}  #:
 
     def scale_to_hertz(self, scale: float) -> float:
         bark = None

--- a/src/pydrobert/speech/scales.py
+++ b/src/pydrobert/speech/scales.py
@@ -25,14 +25,14 @@ import abc
 
 import numpy as np
 
-from pydrobert.speech import AliasedFactory
+from pydrobert.speech.alias import AliasedFactory
 
 __all__ = [
-    "ScalingFunction",
-    "LinearScaling",
-    "OctaveScaling",
-    "MelScaling",
     "BarkScaling",
+    "LinearScaling",
+    "MelScaling",
+    "OctaveScaling",
+    "ScalingFunction",
 ]
 
 
@@ -55,17 +55,14 @@ class LinearScaling(ScalingFunction):
 
     Parameters
     ----------
-    low_hz : float
+    low_hz
         The frequency (in Hertz) corresponding to scale 0.
-    slope_hz : float, optional
+    slope_hz
         The increase in scale corresponding to a 1 Hertz increase in frequency.
-
-    Attributes
-    ----------
-    low_hz : float
-    slope_hz : float
     """
 
+    low_hz: float
+    slop_hz: float
     aliases = {"linear", "uniform"}
 
     def __init__(self, low_hz: float, slope_hz: float = 1.0):
@@ -84,13 +81,9 @@ class OctaveScaling(ScalingFunction):
 
     Parameters
     ----------
-    low_hz : float
+    low_hz
         The positive frequency (in Hertz) corresponding to scale 0. Frequencies below
         this value should never be queried.
-
-    Attributes
-    ----------
-    low_hz : float
 
     Raises
     ------
@@ -98,6 +91,7 @@ class OctaveScaling(ScalingFunction):
         If `low_hz` is non-positive
     """
 
+    low_hz: float
     aliases = {"octave"}
 
     def __init__(self, low_hz: float):

--- a/src/pydrobert/speech/scales.py
+++ b/src/pydrobert/speech/scales.py
@@ -130,7 +130,7 @@ class BarkScaling(ScalingFunction):
 
     Based on a collection experiments briefly mentioned in [zwicker1961]_ involving
     masking to determine critical bands. The functional approximation to the scale is
-    implemented with the formula from [tranmuller1990]_ (being honest, from `Wikipedia
+    implemented with the formula from [traunmuller1990]_ (being honest, from `Wikipedia
     <https://en.wikipedia.org/wiki/Bark_scale>`__):
 
     .. math::

--- a/src/pydrobert/speech/util.py
+++ b/src/pydrobert/speech/util.py
@@ -379,6 +379,7 @@ def read_signal(
         :func:`numpy.fromfile`. The types in :obj:`SOUNDFILE_SUPPORTED_FILE_TYPES`
         are also valid values. `'soundfile'` will use :mod:`soundfile` to read the file
         regardless of the suffix.
+    **kwargs
 
     Returns
     -------
@@ -396,7 +397,6 @@ def read_signal(
 
     Notes
     -----
-
     Python code for reading SPHERE files (not via :mod:soundfile`) was based off of
     `sph2pipe v 2.5
     <https://www.ldc.upenn.edu/language-resources/tools/sphere-conversion-tools>`__.

--- a/src/pydrobert/speech/util.py
+++ b/src/pydrobert/speech/util.py
@@ -391,9 +391,9 @@ def read_signal(
     Kaldi input, and, failing that, via :func:`numpy.fromfile`, we try to read as Kaldi
     input if the file name ends with ``'|'`` and error otherwise. The catch-all
     behaviour was disabled due to the interaction with
-    :obj:`pydrobert.speech.SOUNDFILE_SUPPORTED_FILE_TYPES` whose value depends on the
-    existence of :mod:`soundfile` and the underlying version of
-    `libsndfile <https://libsndfile.github.io/libsndfile>`__.
+    :obj:`pydrobert.speech.config.SOUNDFILE_SUPPORTED_FILE_TYPES` whose value depends on
+    the existence of :mod:`soundfile` and the underlying version of `libsndfile
+    <https://libsndfile.github.io/libsndfile>`__.
 
     Notes
     -----

--- a/src/pydrobert/speech/vis.py
+++ b/src/pydrobert/speech/vis.py
@@ -12,11 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Visualization functions"""
+"""Visualization functions
 
+Raises
+------
+ImportError
+    This submodule requires :mod:`matplotlib`
+"""
 
 from itertools import cycle
-from typing import Optional, Sequence, Tuple, Union, TYPE_CHECKING
+from typing import Optional, Sequence, Tuple, Union
 
 try:
     from typing import Literal
@@ -25,27 +30,32 @@ except ImportError:
 
 import numpy as np
 
+from matplotlib import pyplot as plt
+from matplotlib import ticker
+from matplotlib.axes import Axes
+from matplotlib.colors import Colormap
+from matplotlib.figure import Figure
 from pydrobert.speech.filters import LinearFilterBank
 from pydrobert.speech.compute import FrameComputer, LinearFilterBankFrameComputer
 from pydrobert.speech.post import PostProcessor
 
-if TYPE_CHECKING:
-    # don't want to trip up import errors unless we're sure we're calling something
-    from matplotlib.axes import Axes  # noqa: F401
-    from matplotlib.colors import Colormap  # noqa: F401
-    from matplotlib.figure import Figure  # noqa: F401
+
+__all__ = [
+    "compare_feature_frames",
+    "plot_frequency_response",
+]
 
 
 def plot_frequency_response(
     banks: Union[Sequence[LinearFilterBank], LinearFilterBank],
-    axes: Optional["Axes"] = None,
+    axes: Optional[Axes] = None,
     dft_size: Optional[int] = None,
     half: Optional[bool] = None,
     title: Optional[str] = None,
     x_scale: Literal["hz", "ang", "bins"] = "hz",
     y_scale: Literal["dB", "power", "real", "imag", "both"] = "dB",
-    cmap: "Colormap" = None,
-) -> "Figure":
+    cmap: Colormap = None,
+) -> Figure:
     """Plot frequency response of filters in a filter bank
 
     Parameters
@@ -81,15 +91,7 @@ def plot_frequency_response(
     -------
     fig : matplotlib.figure.Figure
         The containing figure
-
-    Raises
-    ------
-    ImportError
-        If unable to import `matplotlib`
     """
-    from matplotlib import pyplot as plt  # type: ignore
-    from matplotlib import ticker  # type: ignore
-
     try:
         len(banks)
     except AttributeError:  # 1 bank
@@ -259,7 +261,7 @@ def compare_feature_frames(
     post_ops: Optional[Union[PostProcessor, Sequence[PostProcessor]]] = None,
     title: Optional[str] = None,
     **kwargs
-) -> "Figure":
+) -> Figure:
     """Compare features from frame computers via spectrogram-like heat map
 
     Direct comparison of :class:`FrameComputer` objects is possible because all
@@ -315,13 +317,7 @@ def compare_feature_frames(
     -------
     fig : matplotlib.figure.Figure
         The containing figure
-
-    Raises
-    ------
-    ImportError
-        If unable to import `matplotlib`
     """
-    from matplotlib import pyplot as plt
 
     try:
         iter(computers)

--- a/src/pydrobert/speech/vis.py
+++ b/src/pydrobert/speech/vis.py
@@ -17,7 +17,11 @@
 
 from itertools import cycle
 from typing import Optional, Sequence, Tuple, Union, TYPE_CHECKING
-from typing_extensions import Literal
+
+try:
+    from typing import Literal
+except ImportError:
+    from typing_extensions import Literal
 
 import numpy as np
 
@@ -46,22 +50,22 @@ def plot_frequency_response(
 
     Parameters
     ----------
-    bank : banks.LinearFilterBank or sequence
-    axes : matplotlib.axes.Axes, optional
+    bank
+    axes
         An :class:`Axes` object to plot on. Default is to generate a new figure
-    dft_size : int, optional
+    dft_size
         The size of the Discrete Fourier Transform to plot. Defaults to
         ``max(max(bank.supports), 2 * bank.sampling_rate // min(bank.supports_hz)``
-    half : bool, optional
+    half
         Whether to plot the half or full spectrum. Defaults to
         ``bank.is_real``
-    title : str, optional
+    title
         What to call the graph. The default is not to show a title
-    x_scale : {'hz', 'ang', 'bins'}, optional
+    x_scale
         The frequency coordinate scale along the x axis. Hertz
         (:obj:`'hz'`) is cycles/sec, angular frequency (:obj:`'ang'`) is
         radians/sec, and :obj:`'bins'` is the sample index within the DFT
-    y_scale : {'dB', 'power', 'real', 'imag', 'both'}, optional
+    y_scale
         How to express the frequency response along the y axis. Decibels
         (:obj:`'dB'`) is the log of a ratio of the maximum quantity in the
         bank. The range between 0 and -20 decibels is displayed. Power
@@ -69,7 +73,7 @@ def plot_frequency_response(
         response. :obj:`'real'` is the real part of the response,
         :obj:`'imag'` is the imaginary part of the response, and :obj:`'both'`
         displays both :obj:`'real'` and :obj:`'imag'` as separate lines
-    cmap : Colormap, optinal
+    cmap
         A :class:`Colormap` to pull colours from. Defaults to matplotlib's default
         colormap
 
@@ -266,29 +270,29 @@ def compare_feature_frames(
 
     Parameters
     ----------
-    computers : pydrobert.speech.compute.FrameComputer or sequence
+    computers
         One or more frame computers to compare
-    signal : array-like
+    signal
         A 1D array of the raw speech. Assumed to be valid with respect to computer
         settings (e.g. sample rate).
-    axes : matplotlib.axes.Axes or tuple, optional
+    axes
         By default, this function creates a new figure and subplots. Setting one
         `axes` value for every `computers` value will plot feature representations from
         `computers` into each ordered :class:`Axes`. If `axes` do not belong to the same
         figure, a :class:`ValueError` will be raised
-    figure_height : float, optional
+    figure_height
         If a new figure is created, this sets the figure height (in inches). This value
         is determined dynamically according to `figure_width` by default. A
         :class:`ValueError` will be raised if both `figure_height` and `axes` are set
-    figure_width : float, optional
+    figure_width
         If a new figure is created, this set the figure width (in inches). This value
         defaults to 3.33 inches if all subplots are positioned vertically, and to 7
         inches if there are at least two columns of plots. A :class:`ValueError` will be
         raised if both `figure_width` and `axes` are set
-    plot_titles : tuple, optional
+    plot_titles
         An ordered list of strings specifying the titles of each subplot. The default is
         to not display subplot titles
-    positions : tuple, optional
+    positions
         If a new figure is created, `positions` decides how the
         subplots should be positioned relative to one another. Can
         contain only ints (describing the position on only the row-axis)
@@ -296,7 +300,7 @@ def compare_feature_frames(
         must be contiguous and start from index 0 or 0,0 (top or
         top-left). `positions` cannot be specified if `axes` is
         specified
-    post_ops : pydrobert.speech.post.PostProcessor or sequence, optional
+    post_ops
         One or more post-processors to apply (in order) to each computed
         feature representation. If a simple list of post-processors is
         provided, each operation is applied to the default axis (the
@@ -304,7 +308,7 @@ def compare_feature_frames(
         ``(op, axis)`` can be specified in the list. No op is allowed
         to change the shape of the feature representation
         (e.g. :class:`Deltas`), or a :class:`ValueError` will be thrown
-    title : str, optional
+    title
         The title of the whole figure. Default is to display no title
 
     Returns

--- a/tests/test_command_line.py
+++ b/tests/test_command_line.py
@@ -136,7 +136,7 @@ def test_signals_to_torch_feat_dir(temp_dir):
         assert not torch.allclose(signal, noisy.flatten())
         utt2signal[utt_id] = noisy
     torch.manual_seed(70)
-    args.append("--num-workers=4")
+    args.append("--num-workers=2")
     assert not command_line.signals_to_torch_feat_dir(args)
     for utt_id, exp in list(utt2signal.items()):
         act = torch.load(os.path.join(feat_dir, "{}.pt".format(utt_id)))

--- a/tests/test_compute.py
+++ b/tests/test_compute.py
@@ -7,7 +7,7 @@ import pydrobert.speech.compute as compute
 import pydrobert.speech.config as config
 import pytest
 
-from pydrobert.speech.util import alias_factory_subclass_from_arg
+from pydrobert.speech.alias import alias_factory_subclass_from_arg
 from pickle import load as pickle_load
 
 

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -8,7 +8,7 @@ import pydrobert.speech.filters as filters
 import pytest
 
 from pydrobert.speech.config import EFFECTIVE_SUPPORT_THRESHOLD
-from pydrobert.speech.util import alias_factory_subclass_from_arg
+from pydrobert.speech.alias import alias_factory_subclass_from_arg
 
 
 @pytest.fixture(

--- a/tox.ini
+++ b/tox.ini
@@ -3,11 +3,8 @@
 # test suite on all supported python versions. To use it, "pip install tox"
 # and then run "tox" from this directory.
 
-# No wheels for:
-# - pydrobert-kaldi on Windows and py 3.10
-
 [tox]
-envlist = py3{7,8,9,10}
+envlist = py3{7,8,9,10,11}
 isolated_build = True
 required =
     tox-ltt
@@ -18,7 +15,7 @@ deps =
     scipy
     soundfile
     torch
-    !py310: pydrobert-kaldi; sys.platform == 'darwin' or sys.platform == 'linux'
+    pydrobert-kaldi
     
 commands =
     pytest --basetemp="{envtmpdir}" {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -18,4 +18,6 @@ deps =
     pydrobert-kaldi
     
 commands =
+    compute-feats-from-kaldi-tables --help
+    signals-to-torch-feat-dir --help
     pytest --basetemp="{envtmpdir}" {posargs}


### PR DESCRIPTION
Cleanup and backlog stuff for version v0.3.0. In this PR

- Added the `alias` submodule to store alias-related classes and functions. Importing those from `pydrobert.speech` or `pydrobert.speech.utils` is deprecated.
- Updated documentation.
- Some CI stuff to handle deployment