### PR TITLE
Bug fixes, tests, and deprecation warning for preprocessors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Latest
 
+- The `axis` argument of `PreProcessor` is deprecated.
 - `Dither` adds normally-distributed noise rather than uniform noise.
 
 ## v0.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## Latest
+
+- `Dither` adds normally-distributed noise rather than uniform noise.
+
 ## v0.3.0
 
 - Moved `AliasedFactory` and `alias_factory_subclass_from_arg` to `alias`

--- a/src/pydrobert/speech/pre.py
+++ b/src/pydrobert/speech/pre.py
@@ -68,7 +68,7 @@ class Dither(PreProcessor):
     Parameters
     ----------
     coeff
-        Added noise will be in the range ``[-coeff, coeff]``
+        Standard deviation of dither
     """
 
     coeff: float  #:
@@ -85,11 +85,11 @@ class Dither(PreProcessor):
         if not in_place or signal.dtype != np.float64:
             signal = signal.astype(np.float64)
         if axis is None or not signal.shape or len(signal.shape) == 1:
-            signal += self.coeff * np.random.random(signal.shape)
+            signal += self.coeff * np.random.normal(signal.shape)
         else:
             random_shape = [1] * len(signal.shape)
             random_shape[axis] = signal.shape[axis]
-            signal += self.coeff * np.random.random(random_shape)
+            signal += self.coeff * np.random.normal(random_shape)
         return signal.astype(signal_dtype, copy=False)
 
 

--- a/tests/test_pre.py
+++ b/tests/test_pre.py
@@ -1,0 +1,30 @@
+import numpy as np
+
+from pydrobert.speech.pre import *
+
+
+def test_dither():
+    np.random.seed(1)
+    T, std = 100_000, 5
+    dither = Dither(std)
+    b = dither.apply(np.zeros(T))
+    assert b.shape == (T,)
+    assert np.isclose(b.std(0), std, atol=1e-2)
+
+
+def test_preemphasis():
+    np.random.seed(2)
+    preemph = Preemphasize()
+    T = 1028
+    a = np.random.rand(T)
+    A = np.abs(np.fft.rfft(a))
+    A /= A.sum()
+    assert A.shape == (T // 2 + 1,)
+    hi_A = A[T // 2 + 1 :]
+    b = preemph.apply(a)
+    assert a.shape == b.shape
+    B = np.abs(np.fft.rfft(b))
+    B /= B.sum()
+    assert A.shape == B.shape
+    hi_B = B[T // 2 + 1 :]
+    assert np.all(hi_B > hi_A)


### PR DESCRIPTION
This PR solves #20 and adds some testing for the preprocessor frontend. In addition, the 'axis' argument shouldn't be necessary for preprocessors which should only be applied to 1D speech signals. Thus, we're deprecating the 'axis' argument.