### PR TITLE
PyTorch wrappers in pydrobert.speech.torch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@
 - The `axis` argument of `PreProcessor` is deprecated.
 - `Dither` adds normally-distributed noise rather than uniform noise.
 - Added [pytorch](https://pytorch.org/) wrappers around computers under
-  `pydrobert.speech.torch`.
+  `pydrobert.speech.torch`. Preprocessors and STFTFrameComputer have bona
+  fide PyTorch implementations; the rest just wrap the Numpy code.
+- `signals-to-torch-feat-dir` uses the PyTorch implementations.
 
 ## v0.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## Latest
+
+- Added [pytorch](https://pytorch.org/) wrappers around computers under
+  `pydrobert.speech.torch`.
+
 ## v0.3.0
 
 - Moved `AliasedFactory` and `alias_factory_subclass_from_arg` to `alias`

--- a/docs/source/pydrobert.speech.torch.rst
+++ b/docs/source/pydrobert.speech.torch.rst
@@ -1,0 +1,6 @@
+pydrobert.speech.torch
+======================
+
+.. automodule:: pydrobert.speech.torch
+    :members:
+    :show-inheritance:

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,15 @@
+# dev environment
+name: pydrobert-speech
+channels:
+  - pytorch
+  - conda-forge
+  - nodefaults
+dependencies:
+  - matplotlib
+  - numpy
+  - pydrobert-kaldi
+  - pysoundfile
+  - pytest
+  - pytorch
+  - cpuonly
+  - scipy

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,5 +37,6 @@ where = src
 [options.extras_require]
 vis = matplotlib
 kaldi = pydrobert-kaldi
-pytorch = pydrobert-pytorch
+pytorch = 
+  torch >= 1.8
 

--- a/src/pydrobert/speech/compute.py
+++ b/src/pydrobert/speech/compute.py
@@ -698,10 +698,9 @@ class ShortIntegrationFrameComputer(LinearFilterBankFrameComputer):
             self._max_support = max(right - left for left, right in bank.supports)
             self._translation = self._max_support // 2
         else:
-            # we will shift all filters by whatever the minimum value
-            # makes them all supported above/equal 0. We treat all that
-            # translated space as nonzero for the sake of the
-            # overlap-add algorithm
+            # we will shift all filters by whatever minimum value makes them all
+            # supported above/equal 0. We treat all that translated space as nonzero for
+            # the sake of the overlap-add algorithm
             self._translation = 0
             self._max_support = 0
             for left, right in bank.supports:

--- a/src/pydrobert/speech/compute.py
+++ b/src/pydrobert/speech/compute.py
@@ -277,9 +277,12 @@ class ShortTimeFourierTransformFrameComputer(LinearFilterBankFrameComputer):
     use_power
         Whether to sum the power spectrum or the magnitude spectrum
     kaldi_shift
-        If :obj:`True`, the k-th frame will be computed using the signal between
-        ``signal[ k - frame_length // 2 + frame_shift // 2:k + (frame_length + 1) // 2
-        + frame_shift // 2]``. These are the frame bounds for Kaldi [povey2011]_.
+        Dictates how to center frames when `frame_style` is :obj:`'centered'`. If
+        :obj:`True`, the k-th frame will be computed using the signal between ``signal[
+        k * frame_shift - frame_length // 2 + frame_shift // 2:k * frame_shift +
+        (frame_length + 1) // 2 + frame_shift // 2]``. These are the frame bounds for
+        Kaldi [povey2011]_. Otherwise, the k-th frame is ``signal[ k * frame_shift -
+        (frame_length + 1) // 2 + 1: k * frame_shift + frame_length // 2 + 1]``.
     """
 
     aliases = {"stft"}  #:

--- a/src/pydrobert/speech/filters.py
+++ b/src/pydrobert/speech/filters.py
@@ -284,15 +284,16 @@ class TriangularOverlappingFilterBank(LinearFilterBank):
         scaling_function = alias_factory_subclass_from_arg(
             ScalingFunction, scaling_function
         )
-        if low_hz < 0 or (
-            high_hz and (high_hz <= low_hz or high_hz > sampling_rate // 2)
-        ):
+        nyquist = sampling_rate / 2
+        if high_hz is None:
+            high_hz = nyquist
+        # allow 1Hz-leeway for floating point / serialization errors
+        if not (0 <= low_hz < high_hz <= nyquist + 1):
             raise ValueError(
                 "Invalid frequency range: ({:.2f},{:.2f}".format(low_hz, high_hz)
             )
+        high_hz = min(high_hz, nyquist)
         self._rate = sampling_rate
-        if high_hz is None:
-            high_hz = sampling_rate // 2
         # compute vertices
         scale_low = scaling_function.hertz_to_scale(low_hz)
         scale_high = scaling_function.hertz_to_scale(high_hz)

--- a/src/pydrobert/speech/torch.py
+++ b/src/pydrobert/speech/torch.py
@@ -1,0 +1,331 @@
+# Copyright 2023 Sean Robertson
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""PyTorch compatibility"""
+
+import math
+
+from typing_extensions import Self
+from typing import Collection, List, Literal, Optional, Sequence, Tuple, Union
+
+import torch
+
+from . import config
+from .compute import STFTFrameComputer
+
+__all__ = [
+    "PyTorchSTFTFrameComputer",
+    "stft_frame_computer",
+]
+
+
+def check_in(name: str, val: str, choices: Collection[str]):
+    if val not in choices:
+        choices = "', '".join(sorted(choices))
+        raise ValueError(f"Expected {name} to be one of '{choices}'; got '{val}'")
+
+
+def check_positive(name: str, val, nonnegative=False):
+    pos = "non-negative" if nonnegative else "positive"
+    if val < 0 or (val == 0 and not nonnegative):
+        raise ValueError(f"Expected {name} to be {pos}; got {val}")
+
+
+@torch.jit.script_if_tracing
+def stft_frame_computer(
+    sig: torch.Tensor,
+    filters: List[torch.Tensor],
+    offsets: List[int],
+    frame_length: int,
+    frame_shift: int,
+    centered: bool = True,
+    window: Optional[torch.Tensor] = None,
+    dft_size: Optional[int] = None,
+    use_log: bool = True,
+    use_power: bool = False,
+    include_energy: bool = False,
+    kaldi_shift: bool = False,
+    is_real: bool = True,
+    eps: float = config.LOG_FLOOR_VALUE,
+) -> torch.Tensor:
+    """Functional implementation of PyTorchSTFTFrameComputer"""
+    if dft_size is None:
+        dft_size = 2 ** math.ceil(math.log2(frame_length))
+    elif dft_size < frame_length:
+        raise RuntimeError(f"expected dft_size gte {frame_length}; got {dft_size}")
+    num_filts = len(filters)
+    if num_filts != len(offsets):
+        raise RuntimeError(
+            f"filters ({num_filts}) has different length than offsets "
+            f"({len(offsets)})"
+        )
+    if sig.ndim != 1:
+        raise RuntimeError(f"Expected x to be 1-dimensional; got {sig.ndim}")
+    if window is not None and window.shape != (frame_length,):
+        raise RuntimeError(
+            f"Expected window to have shape {(frame_length,)}; got {window.shape}"
+        )
+    sig_len = sig.size(0)
+    if sig_len < frame_length // 2 + 1:
+        return sig.new_empty((0, num_filts))
+    zero = sig.new_zeros(1)
+    if not centered:
+        pad_left = 0
+    elif kaldi_shift:
+        pad_left = frame_length // 2 - frame_shift // 2
+    else:
+        pad_left = (frame_length + 1) // 2 - 1
+    num_frames = max(0, (sig_len + frame_shift // 2) // frame_shift)
+    total_len = (num_frames - 1) * frame_shift - pad_left + frame_length
+    pad_right = max(0, total_len - sig_len)
+    if pad_left or pad_right:
+        # symmetric padding
+        sig_ = sig.flip(0)
+        sig = torch.cat([sig_[sig_len - pad_left :], sig, sig_[:pad_right]])
+        del sig_
+    sig = sig.as_strided((num_frames, frame_length), (frame_shift, 1))
+    y: List[torch.Tensor] = []
+    if include_energy:
+        energy = torch.linalg.norm(sig, 1, 1) / frame_length
+        if not use_power:
+            energy = energy.sqrt()
+        y.append(energy)
+    if window is not None:
+        sig = sig * window
+    spect = torch.fft.rfft(sig, dft_size, 1, "backward")
+    del sig
+    half_len = spect.size(1)
+    mod = half_len % 2
+    for si, filt in zip(offsets, filters):
+        val, consumed, conj, filt_len = zero, 0, False, len(filt)
+        while consumed < filt_len:
+            if conj:
+                seg_len = max(min(si + filt_len - consumed, half_len - 2 + mod) - si, 0)
+                seg = spect[..., -2 + mod - si - seg_len : -2 + mod - si].conj().flip(1)
+                si -= half_len - 2 + mod
+            else:
+                seg_len = max(0, min(si + filt_len - consumed, half_len) - si)
+                seg = spect[..., si : si + seg_len]
+                si -= half_len
+            seg = seg * filt[consumed : consumed + seg_len]
+            if use_power:
+                val_f = torch.linalg.norm(seg, 2, 1).square()
+            else:
+                val_f = seg.abs().sum(1)
+            val = val + val_f
+            conj = not conj
+            consumed += seg_len
+            si = max(0, si)
+            del seg, val_f
+        y.append(val)
+    y_ = torch.stack(y, 1)
+    if is_real:
+        y_ = y_ * 2
+    if use_log:
+        y_ = y_.clamp_min(eps).log()
+    return y_
+
+
+class PyTorchSTFTFrameComputer(torch.nn.Module):
+    """PyTorch implementation of STFTFrameComputer
+
+    This module is a port of :class:`pydrobert.speech.compute.STFTFrameComputer` to
+    PyTorch. When called, the output should be nearly identical to a call to
+    :func:`STFTFrameComputer.compute_full`, except :class:`torch.Tensor` inputs and
+    outputs are expected.
+
+    The easiest means of initializing this module is through the factory function
+    :func:`PytorchSTFTFrameComputer.from_numpy_frame_computer`, which determines the
+    below parameters from an :class:`STFTFrameComputer` which has already been
+    initialized.
+
+    The filters and window are learnable/adjustable. Be sure to disable gradients with
+    :func:`torch.no_grad` if a fixed feature representation is desirable.
+
+    Parameters
+    ----------
+    offsets_and_truncated_filters
+        A sequence of pairs ``(offset, truncated_filter)``. `truncated_filter` is a
+        one-dimensional tensor of the non-zero frequency response of a single filter in
+        the bank. `offset` is the index in the short-time spectrum at which the
+        `truncated_filter` begins.
+    frame_length
+        The number of audio samples constituting a frame.
+    frame_shift
+        The number of audio samples between subsequent frames.
+    frame_style
+        If ``'causal'``, the first frame begins at sample ``0``. Otherwise, the
+        first frame is centered around sample ``0`` with the exact behaviour dictated
+        by the `kaldi_shift` flag.
+    window
+        If specified, a tensor of shape ``(frame_length,)`` containing the windowing
+        function. If unspecified, implicit rectangular windowing will be performed
+        (with no gradient).
+    dft_size
+        The size of the spectrum to compute for each frame. Must be greater than
+        or equal to `frame_length`. If unspecified, the first power of two at or beyond
+        the frame length will be chosen.
+    use_log
+        Whether to take the logarithm of the resulting representation
+    use_power
+        Take the power spectrum instead of the magnitude spectrum
+    include_energy
+        Whether to add a coefficient at index 0 corresponding to the frame-wise energy
+        of the signal
+    kaldi_shift
+        Dictates how to center frames when `frame_style` is :obj:`'centered'`. If
+        :obj:`True`, the k-th frame will be computed using the signal between ``signal[
+        k * frame_shift - frame_length // 2 + frame_shift // 2:k * frame_shift +
+        (frame_length + 1) // 2 + frame_shift // 2]``. These are the frame bounds for
+        Kaldi [povey2011]_. Otherwise, the k-th frame is ``signal[ k * frame_shift -
+        (frame_length + 1) // 2 + 1: k * frame_shift + frame_length // 2 + 1]``.
+    is_real
+        Whether the filters are real in the time domain. If :obj:`True`, coefficients
+        will be doubled (pre-log) to account for Hermitian symmetry.
+    """
+
+    __slots__ = (
+        "centered",
+        "dft_size",
+        "frame_length",
+        "frame_shift",
+        "offsets",
+        "use_energy",
+        "use_log",
+        "use_power",
+    )
+
+    centered: bool
+    dft_size: int
+    frame_length: int
+    frame_shift: int
+    offsets: Tuple[int, ...]
+    use_energy: bool
+    use_log: bool
+    use_power: bool
+    kaldi_shift: bool
+    is_real: bool
+
+    def __init__(
+        self,
+        offsets_and_truncated_filters: Sequence[Tuple[int, torch.Tensor]],
+        frame_length: int,
+        frame_shift: int,
+        frame_style: Literal["centered", "causal"] = "centered",
+        window: Optional[torch.Tensor] = None,
+        dft_size: Optional[int] = None,
+        use_log: bool = True,
+        use_power: bool = False,
+        include_energy: bool = False,
+        kaldi_shift: bool = False,
+        is_real: bool = False,
+    ) -> None:
+        offsets, filters = [], []
+        for i, (offset, filter) in enumerate(offsets_and_truncated_filters):
+            if filter.ndim != 1:
+                raise ValueError(f"filter {i} is not a vector")
+            elif not filter.size(0):
+                raise ValueError(f"filter {i} is empty")
+            check_positive(f"filter {i} offset", offset, True)
+            offsets.append(offset)
+            filters.append(filter)
+        check_positive("frame_length", frame_length)
+        check_positive("frame_shift", frame_shift)
+        check_in("frame_style", frame_style, {"causal", "centered"})
+        if window is not None:
+            if window.shape != (frame_length,):
+                raise ValueError(
+                    f"Expected window.shape to be ({frame_length},); got {window.shape}"
+                )
+        if dft_size is None:
+            dft_size = 2 ** math.ceil(math.log2(frame_length))
+        elif dft_size < frame_length:
+            raise ValueError(
+                f"Expected dft_size to be gte {frame_length}; got {dft_size}"
+            )
+        super().__init__()
+        self.frame_length, self.frame_shift = frame_length, frame_shift
+        self.offsets, self.centered = tuple(offsets), frame_style == "centered"
+        self.dft_size, self.use_log, self.use_power = dft_size, use_log, use_power
+        self.kaldi_shift, self.is_real = kaldi_shift, is_real
+        self.include_energy = include_energy
+
+        self.filters = torch.nn.ParameterList(filters)
+        if window is None:
+            self.register_parameter("window", None)
+        else:
+            self.window = torch.nn.Parameter(window)
+
+    @classmethod
+    def from_numpy_frame_computer(
+        cls,
+        computer: STFTFrameComputer,
+        filter_type: torch.dtype = torch.cfloat,
+        window_type: torch.dtype = torch.float,
+    ) -> Self:
+        """Create an instance using an STFTFrameComputer
+
+        Parameters
+        ----------
+        computer
+            The initialized instance to pull parameters from
+        filter_type
+            The data type to store filter parameters as
+        window_type
+            The data type to store the window parameter as
+        """
+        filters = [
+            (o, torch.tensor(x, dtype=filter_type))
+            for (o, x) in zip(computer._filt_start_idxs, computer._truncated_filts)
+        ]
+        frame_length = computer.frame_length
+        frame_shift = computer.frame_shift
+        frame_style = computer._frame_style
+        window = torch.tensor(computer._window, dtype=window_type)
+        dft_size = computer._dft_size
+        use_log = computer._log
+        use_power = computer._power
+        include_energy = computer._include_energy
+        kaldi_shift = computer._kaldi_shift
+        is_real = computer._real
+        return cls(
+            filters,
+            frame_length,
+            frame_shift,
+            frame_style,
+            window,
+            dft_size,
+            use_log,
+            use_power,
+            include_energy,
+            kaldi_shift,
+            is_real,
+        )
+
+    def forward(self, signal: torch.Tensor) -> torch.Tensor:
+        return stft_frame_computer(
+            signal,
+            self.filters,
+            self.offsets,
+            self.frame_length,
+            self.frame_shift,
+            self.centered,
+            self.window,
+            self.dft_size,
+            self.use_log,
+            self.use_power,
+            self.include_energy,
+            self.kaldi_shift,
+            self.is_real,
+        )

--- a/src/pydrobert/speech/torch.py
+++ b/src/pydrobert/speech/torch.py
@@ -16,8 +16,8 @@
 
 import math
 
-from typing_extensions import Self
-from typing import Collection, List, Literal, Optional, Sequence, Tuple, Union
+from typing_extensions import Self, Literal
+from typing import Collection, List, Optional, Sequence, Tuple
 
 import torch
 

--- a/src/pydrobert/speech/torch.py
+++ b/src/pydrobert/speech/torch.py
@@ -38,8 +38,10 @@ from .pre import Dither
 from .compute import STFTFrameComputer
 
 __all__ = [
-    "PyTorchSTFTFrameComputer",
+    "pytorch_dither",
     "pytorch_stft_frame_computer",
+    "PyTorchDither",
+    "PyTorchSTFTFrameComputer",
 ]
 
 
@@ -55,7 +57,7 @@ def check_positive(name: str, val, nonnegative=False):
         raise ValueError(f"Expected {name} to be {pos}; got {val}")
 
 
-def pytorch_dither(sig: torch.Tensor, coeff: torch.float = 1.0) -> torch.Tensor:
+def pytorch_dither(sig: torch.Tensor, coeff: float = 1.0) -> torch.Tensor:
     return sig + coeff * torch.randn_like(sig)
 
 
@@ -77,13 +79,17 @@ class PyTorchDither(torch.nn.Module):
     training, dithering serves a
     """
 
-    __constants__ = "coeff"
+    __constants__ = ("coeff",)
     coeff: float
 
     def __init__(self, coeff: float = 1.0):
         check_positive("coeff", coeff, True)
         super().__init__()
         self.coeff = coeff
+
+    @classmethod
+    def from_dither(cls, dither: Dither) -> Self:
+        return PyTorchDither(dither.coeff)
 
     def forward(self, sig: torch.Tensor) -> torch.Tensor:
         return pytorch_dither(sig, self.coeff)

--- a/tests/test_torch.py
+++ b/tests/test_torch.py
@@ -116,9 +116,7 @@ def test_pytorch_short_integration_frame_computer(include_energy, jit_type):
     signal = torch.randn(16_000)
     json_ = dict(name="si", bank="fbank", include_energy=include_energy,)
     computer_numpy = alias_factory_subclass_from_arg(compute.FrameComputer, json_)
-    computer_pytorch = PyTorchShortIntegrationFrameComputer.from_short_integration_frame_computer(
-        computer_numpy
-    )
+    computer_pytorch = PyTorchSIFrameComputer.from_si_frame_computer(computer_numpy)
     if jit_type == "script":
         computer_pytorch = torch.jit.script(computer_pytorch)
     elif jit_type == "trace":

--- a/tests/test_torch.py
+++ b/tests/test_torch.py
@@ -1,0 +1,36 @@
+import os
+import json
+
+import pytest
+import numpy as np
+
+try:
+    import torch
+
+    skip = False
+except ImportError:
+    skip = True
+
+import pydrobert.speech.compute as compute
+
+from pydrobert.speech.torch import PyTorchSTFTFrameComputer
+from pydrobert.speech.alias import alias_factory_subclass_from_arg
+
+pytestmark = pytest.mark.skipif(skip, reason="Could not import pytorch")
+
+
+def test_stft_frame_computer_wrapper():
+    torch.manual_seed(1)
+    signal = torch.randn(16_000)
+    data_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "data")
+    with open(os.path.join(data_dir, "fbank.json")) as json_file:
+        computer_numpy = alias_factory_subclass_from_arg(
+            compute.FrameComputer, json.load(json_file)
+        )
+    computer_pytorch = PyTorchSTFTFrameComputer.from_numpy_frame_computer(
+        computer_numpy
+    )
+    exp = computer_numpy.compute_full(signal.numpy())
+    with torch.no_grad():
+        act = computer_pytorch(signal).numpy()
+    assert np.allclose(exp, act)

--- a/tests/test_torch.py
+++ b/tests/test_torch.py
@@ -19,18 +19,24 @@ from pydrobert.speech.alias import alias_factory_subclass_from_arg
 pytestmark = pytest.mark.skipif(skip, reason="Could not import pytorch")
 
 
-def test_stft_frame_computer_wrapper():
+@pytest.mark.parametrize("include_energy", [True, False], ids=["energy", "noenergy"])
+@pytest.mark.parametrize("jit_type", ["script", "trace", "none"])
+def test_pytorch_stft_frame_computer(include_energy, jit_type):
     torch.manual_seed(1)
     signal = torch.randn(16_000)
     data_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "data")
     with open(os.path.join(data_dir, "fbank.json")) as json_file:
-        computer_numpy = alias_factory_subclass_from_arg(
-            compute.FrameComputer, json.load(json_file)
-        )
+        json_ = json.load(json_file)
+    json_["include_energy"] = include_energy
+    computer_numpy = alias_factory_subclass_from_arg(compute.FrameComputer, json_)
     computer_pytorch = PyTorchSTFTFrameComputer.from_numpy_frame_computer(
         computer_numpy
     )
+    if jit_type == "script":
+        computer_pytorch = torch.jit.script(computer_pytorch)
+    elif jit_type == "trace":
+        computer_pytorch = torch.jit.trace(computer_pytorch, (torch.empty(1),))
     exp = computer_numpy.compute_full(signal.numpy())
     with torch.no_grad():
         act = computer_pytorch(signal).numpy()
-    assert np.allclose(exp, act)
+    assert np.allclose(exp, act, atol=1e-5)

--- a/tests/test_torch.py
+++ b/tests/test_torch.py
@@ -29,9 +29,7 @@ def test_pytorch_stft_frame_computer(include_energy, jit_type):
         json_ = json.load(json_file)
     json_["include_energy"] = include_energy
     computer_numpy = alias_factory_subclass_from_arg(compute.FrameComputer, json_)
-    computer_pytorch = PyTorchSTFTFrameComputer.from_numpy_frame_computer(
-        computer_numpy
-    )
+    computer_pytorch = PyTorchSTFTFrameComputer.from_stft_frame_computer(computer_numpy)
     if jit_type == "script":
         computer_pytorch = torch.jit.script(computer_pytorch)
     elif jit_type == "trace":

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ deps =
     pytest
     scipy
     soundfile
-    torch
+    torch >=1.8
     pydrobert-kaldi
     
 commands =


### PR DESCRIPTION
In an effort to speed up computations as well as make the feature front-end accessible to PyTorch, I've added a new submodule `torch` to this package. It adds PyTorch modules for code in `pydrobert.speech.{pre,compute,post}`. `pre` and `STFTFrameComputer` have been reimplemented in PyTorch; `post` and `SIFrameComputer` merely wrap the Numpy modules. More than a wrapper for post-processors would be superfluous as they have already been implemented in `pydrobert.torch`. `SIFrameComputer`, on the other hand, should be reimplemented.

Modules pull the internal state of Numpy analogues in order to be initialized. This makes the PyTorch implementations tightly connected to their Numpy implementations and thus unsuited for inclusion in `pydrobert.torch`.