### PR TITLE
Add YAML 1.2 support for CLI configs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,11 @@
 
 ## v0.4.0
 
-- [webdataset](https://github.com/webdataset) hook in `pydrobert.speech.util`
-- Python 3.12 support
-- `read_signal` can read from binary I/O
+- CLI now allows configs to be specified as YAML files. If JSON parsing fails,
+  will silently switch to YAML.
+- [webdataset](https://github.com/webdataset) hook in `pydrobert.speech.util`.
+- Python 3.12 support.
+- `read_signal` can read from binary I/O.
 - Added `--manifest` option to `signals-to-torch-feature-dir`.
 - The `axis` argument of `PreProcessor` is deprecated.
 - `Dither` adds normally-distributed noise rather than uniform noise.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 ## v0.4.0
 
-- CLI now allows configs to be specified as YAML files. If JSON parsing fails,
-  will silently switch to YAML.
+- CLI now quietly reads configs as YAML 1.2 via
+  [ruamel.yaml](https://yaml.readthedocs.io/en/latest/) if installed. As JSON
+  is valid YAML 1.2, it shouldn't break anything.
 - [webdataset](https://github.com/webdataset) hook in `pydrobert.speech.util`.
 - Python 3.12 support.
 - `read_signal` can read from binary I/O.

--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -7,9 +7,7 @@ compute-feats-from-kaldi-tables
 ::
 
   compute-feats-from-kaldi-tables -h
-  usage: compute-feats-from-kaldi-tables [-h] [-v VERBOSE] [--config CONFIG] [--print-args PRINT_ARGS] [--min-duration MIN_DURATION] [--channel CHANNEL]
-                                         [--preprocess PREPROCESS] [--postprocess POSTPROCESS] [--seed SEED]
-                                         wav_rspecifier feats_wspecifier computer_config
+  usage: compute-feats-from-kaldi-tables [-h] [-v VERBOSE] [--config CONFIG] [--print-args PRINT_ARGS] [--min-duration MIN_DURATION] [--channel CHANNEL] [--preprocess PREPROCESS] [--postprocess POSTPROCESS] [--seed SEED] wav_rspecifier feats_wspecifier computer_config
   
   Store features from a kaldi archive in a kaldi archive
   
@@ -34,17 +32,20 @@ compute-feats-from-kaldi-tables
     --preprocess PREPROCESS
                           JSON list of configurations for 'pydrobert.speech.pre.PreProcessor' objects. Audio will be preprocessed in the same order as the list
     --postprocess POSTPROCESS
-                          JSON List of configurations for 'pydrobert.speech.post.PostProcessor' objects. Features will be postprocessed in the same order as the list
+                          JSON list of configurations for 'pydrobert.speech.post.PostProcessor' objects. Features will be postprocessed in the same order as the list
     --seed SEED           A random seed used for determinism. This affects operations like dithering. If unset, a seed will be generated at the moment
+  
+  New in version 0.4.0: if ruamel.yaml is installed
+  (https://yaml.readthedocs.io/en/latest/), JSON arguments will be parsed as YAML 1.2
+  by default. As JSON is valid YAML 1.2, you can continue to use JSON for configurations.
 
 signals-to-torch-feat-dir
 -------------------------
 
 ::
 
-  usage: signals-to-torch-feat-dir [-h] [--channel CHANNEL] [--preprocess PREPROCESS] [--postprocess POSTPROCESS]
-                                   [--force-as {flac,npz,table,hdf5,soundfile,npy,ogg,wav,aiff,sph,file,kaldi,pt}] [--seed SEED] [--file-prefix FILE_PREFIX]
-                                   [--file-suffix FILE_SUFFIX] [--num-workers NUM_WORKERS] [--manifest MANIFEST]
+  usage: signals-to-torch-feat-dir [-h] [--channel CHANNEL] [--preprocess PREPROCESS] [--postprocess POSTPROCESS] [--force-as {aiff,npz,hdf5,table,kaldi,soundfile,pt,ogg,npy,file,flac,sph,wav}] [--seed SEED] [--file-prefix FILE_PREFIX] [--file-suffix FILE_SUFFIX] [--num-workers NUM_WORKERS]
+                                   [--manifest MANIFEST]
                                    map [computer_config] dir
   
   Convert a map of signals to a torch SpectDataSet
@@ -81,8 +82,7 @@ signals-to-torch-feat-dir
   
   positional arguments:
     map                   Path to the file containing (<utterance>, <path>) pairs
-    computer_config       JSON file or string to configure a pydrobert.speech.compute.FrameComputer object to calculate features with. If unspecified, the audio (with
-                          channels removed) will be stored directly with shape (S, 1), where S is the number of samples
+    computer_config       JSON file or string to configure a pydrobert.speech.compute.FrameComputer object to calculate features with. If unspecified, the audio (with channels removed) will be stored directly with shape (S, 1), where S is the number of samples
     dir                   Directory to output features to. If the directory does not exist, it will be created
   
   options:
@@ -91,19 +91,20 @@ signals-to-torch-feat-dir
     --preprocess PREPROCESS
                           JSON list of configurations for 'pydrobert.speech.pre.PreProcessor' objects. Audio will be preprocessed in the same order as the list
     --postprocess POSTPROCESS
-                          JSON List of configurations for 'pydrobert.speech.post.PostProcessor' objects. Features will be postprocessed in the same order as the list
-    --force-as {flac,npz,table,hdf5,soundfile,npy,ogg,wav,aiff,sph,file,kaldi,pt}
-                          Force the paths in 'map' to be interpreted as a specific type of data. table: kaldi table (key is utterance id); wav: wave file; hdf5: HDF5
-                          archive (key is utterance id); npy: Numpy binary; npz: numpy archive (key is utterance id); pt: PyTorch binary; sph: NIST SPHERE file; kaldi:
-                          kaldi object; file: numpy.fromfile binary. soundfile: force soundfile processing.
+                          JSON list of configurations for 'pydrobert.speech.post.PostProcessor' objects. Features will be postprocessed in the same order as the list
+    --force-as {aiff,npz,hdf5,table,kaldi,soundfile,pt,ogg,npy,file,flac,sph,wav}
+                          Force the paths in 'map' to be interpreted as a specific type of data. table: kaldi table (key is utterance id); wav: wave file; hdf5: HDF5 archive (key is utterance id); npy: Numpy binary; npz: numpy archive (key is utterance id); pt: PyTorch binary; sph: NIST
+                          SPHERE file; kaldi: kaldi object; file: numpy.fromfile binary. soundfile: force soundfile processing.
     --seed SEED           A random seed used for determinism. This affects operations like dithering. If unset, a seed will be generated at the moment
     --file-prefix FILE_PREFIX
                           The file prefix indicating a torch data file
     --file-suffix FILE_SUFFIX
                           The file suffix indicating a torch data file
     --num-workers NUM_WORKERS
-                          The number of workers simultaneously computing features. Should not affect determinism when used in tandem with --seed. '0' means all work is
-                          done on the main thread
-    --manifest MANIFEST   If specified, a list of utterances which have already been computed will be stored in this file. Utterances already listed in the file will be
-                          not be computed. Useful for resuming computations after an unexpected termination
+                          The number of workers simultaneously computing features. Should not affect determinism when used in tandem with --seed. '0' means all work is done on the main thread
+    --manifest MANIFEST   If specified, a list of utterances which have already been computed will be stored in this file. Utterances already listed in the file will be not be computed. Useful for resuming computations after an unexpected termination
+  
+  New in version 0.4.0: if ruamel.yaml is installed
+  (https://yaml.readthedocs.io/en/latest/), JSON arguments will be parsed as YAML 1.2
+  by default. As JSON is valid YAML 1.2, you can continue to use JSON for configurations.
 

--- a/environment.yml
+++ b/environment.yml
@@ -14,5 +14,7 @@ dependencies:
   - pysoundfile
   - pytest
   - pytorch
+  - pyyaml
+  - ruamel.yaml
   - scipy
   - webdataset

--- a/environment.yml
+++ b/environment.yml
@@ -14,7 +14,6 @@ dependencies:
   - pysoundfile
   - pytest
   - pytorch
-  - pyyaml
   - ruamel.yaml
   - scipy
   - webdataset

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,8 +40,10 @@ kaldi = pydrobert-kaldi
 wds = webdataset
 hdf5 = h5py
 soundfile = soundfile
+yaml =
+  ruamel.yaml >=0.15
 pytorch = 
-  torch >= 1.8
+  torch >=1.8
 all =
   matplotlib
   pydrobert-kaldi
@@ -49,4 +51,5 @@ all =
   torch >= 1.8
   h5py
   soundfile
+  ruamel.yaml >=0.15
 

--- a/src/pydrobert/speech/config.py
+++ b/src/pydrobert/speech/config.py
@@ -14,13 +14,14 @@
 
 """Package constants used throughout pydrobert.speech"""
 
-from typing import Set
+from typing import Set, Tuple
 
 __all__ = [
     "EFFECTIVE_SUPPORT_THRESHOLD",
     "LOG_FLOOR_VALUE",
     "SOUNDFILE_SUPPORTED_FILE_TYPES",
     "USE_FFTPACK",
+    "YAML_MODULE_PRIORITIES",
 ]
 
 
@@ -84,3 +85,14 @@ try:
 except ImportError:
     pass
 
+__all__ = [
+    "YAML_MODULE_PRIORITIES",
+]
+
+
+YAML_MODULE_PRIORITIES: Tuple[str] = ("ruamel.yaml", "yaml")
+"""Specifies the order with which to try YAML parser modules
+
+A number of different `YAML syntax <https://en.wikipedia.org/wiki/YAML>`__ parsers
+exist. This tuple specifies the order by which we attempt to import parsers.
+"""

--- a/src/pydrobert/speech/config.py
+++ b/src/pydrobert/speech/config.py
@@ -14,18 +14,17 @@
 
 """Package constants used throughout pydrobert.speech"""
 
-from typing import Set, Tuple
+from typing import Set
 
 __all__ = [
     "EFFECTIVE_SUPPORT_THRESHOLD",
     "LOG_FLOOR_VALUE",
     "SOUNDFILE_SUPPORTED_FILE_TYPES",
     "USE_FFTPACK",
-    "YAML_MODULE_PRIORITIES",
 ]
 
 
-USE_FFTPACK = False
+USE_FFTPACK: bool = False
 """bool : Whether to use :mod:`scipy.fftpack`
 
 The scipy implementation of the FFT can be much faster than the numpy one. This is set
@@ -41,7 +40,7 @@ try:
 except ImportError:
     pass
 
-EFFECTIVE_SUPPORT_THRESHOLD = 5e-4
+EFFECTIVE_SUPPORT_THRESHOLD: float = 5e-4
 """float : Value considered roughly zero for support computations
 
 No function is compactly supported in both the time and Fourier domains, but large
@@ -50,7 +49,7 @@ zero. The higher it is, the more accurate computations will be, but the longer t
 take
 """
 
-LOG_FLOOR_VALUE = 1e-5
+LOG_FLOOR_VALUE: float = 1e-5
 """float : Value used as floor when taking log in computations"""
 
 
@@ -84,15 +83,3 @@ try:
 
 except ImportError:
     pass
-
-__all__ = [
-    "YAML_MODULE_PRIORITIES",
-]
-
-
-YAML_MODULE_PRIORITIES: Tuple[str] = ("ruamel.yaml", "yaml")
-"""Specifies the order with which to try YAML parser modules
-
-A number of different `YAML syntax <https://en.wikipedia.org/wiki/YAML>`__ parsers
-exist. This tuple specifies the order by which we attempt to import parsers.
-"""

--- a/tests/data/fbank.yaml
+++ b/tests/data/fbank.yaml
@@ -1,0 +1,17 @@
+name: stft
+bank:
+  name: fbank
+  num_filts: 40
+  low_hz: 20
+  high_hz: 8000
+  sampling_rate: 16000
+  analytic: false
+frame_length_ms: 25
+frame_shift_ms: 10
+frame_style: centered
+include_energy: false
+pad_to_nearest_power_of_two: true
+window_function: hanning
+use_log: true
+use_power: true
+kaldi_shift: true

--- a/tests/test_command_line.py
+++ b/tests/test_command_line.py
@@ -1,5 +1,6 @@
 import os
 import wave
+import importlib
 
 import numpy as np
 import pytest
@@ -10,6 +11,10 @@ from pydrobert.speech import command_line, config
 @pytest.fixture(params=["ruamel.yaml", "pyyaml", "json"])
 def config_type(request):
     if request.param.endswith("yaml"):
+        try:
+            importlib.util.find_spec(request.param)
+        except:
+            pytest.skip(f"{request.param} unavailable")
         old_props = config.YAML_MODULE_PRIORITIES
         config.YAML_MODULE_PRIORITIES = (request.param,)
         yield "yaml"

--- a/tests/test_command_line.py
+++ b/tests/test_command_line.py
@@ -5,22 +5,17 @@ import importlib
 import numpy as np
 import pytest
 
-from pydrobert.speech import command_line, config
+from pydrobert.speech import command_line
 
 
-@pytest.fixture(params=["ruamel.yaml", "pyyaml", "json"])
+@pytest.fixture(params=["yaml", "json"])
 def config_type(request):
-    if request.param.endswith("yaml"):
+    if request.param == "yaml":
         try:
-            importlib.util.find_spec(request.param)
-        except:
-            pytest.skip(f"{request.param} unavailable")
-        old_props = config.YAML_MODULE_PRIORITIES
-        config.YAML_MODULE_PRIORITIES = (request.param,)
-        yield "yaml"
-        config.YAML_MODULE_PRIORITIES = old_props
-    else:
-        yield request.param
+            import ruamel.yaml
+        except ImportError:
+            pytest.skip("cannot import ruamel.yaml")
+    yield request.param
 
 
 def test_compute_feats_from_kaldi_tables(temp_dir, config_type):

--- a/tests/test_command_line.py
+++ b/tests/test_command_line.py
@@ -4,10 +4,21 @@ import wave
 import numpy as np
 import pytest
 
-from pydrobert.speech import command_line
+from pydrobert.speech import command_line, config
 
 
-def test_compute_feats_from_kaldi_tables(temp_dir):
+@pytest.fixture(params=["ruamel.yaml", "pyyaml", "json"])
+def config_type(request):
+    if request.param.endswith("yaml"):
+        old_props = config.YAML_MODULE_PRIORITIES
+        config.YAML_MODULE_PRIORITIES = (request.param,)
+        yield "yaml"
+        config.YAML_MODULE_PRIORITIES = old_props
+    else:
+        yield request.param
+
+
+def test_compute_feats_from_kaldi_tables(temp_dir, config_type):
     kaldi_io = pytest.importorskip("pydrobert.kaldi.io")
     np.random.seed(5)
     wav_scp = os.path.join(temp_dir, "wav.scp")
@@ -19,14 +30,20 @@ def test_compute_feats_from_kaldi_tables(temp_dir):
     num_digits = int(np.log10(num_utts)) + 1
     utt_fmt = "utt{{:0{}d}}".format(num_digits)
     computer_json_path = os.path.join(
-        os.path.dirname(os.path.realpath(__file__)), "data", "fbank.json"
+        os.path.dirname(os.path.realpath(__file__)), "data", f"fbank.{config_type}"
     )
-    preprocessor_json_path = os.path.join(temp_dir, "preprocess.json")
-    postprocessor_json_path = os.path.join(temp_dir, "unit.json")
+    preprocessor_json_path = os.path.join(temp_dir, f"preprocess.{config_type}")
+    postprocessor_json_path = os.path.join(temp_dir, f"unit.{config_type}")
     with open(preprocessor_json_path, "w") as f:
-        f.write('["dither"]\n')
+        if config_type == "yaml":
+            f.write("- name: dither\n")
+        else:
+            f.write('["dither"]\n')
     with open(postprocessor_json_path, "w") as f:
-        f.write('["unit"]\n')
+        if config_type == "yuaml":
+            f.write("- name: unit\n")
+        else:
+            f.write('["unit"]\n')
     if not os.path.isdir(wav_file_dir):
         os.makedirs(wav_file_dir)
     with open(wav_scp, "w") as scp:
@@ -35,7 +52,7 @@ def test_compute_feats_from_kaldi_tables(temp_dir):
             wav_path = os.path.join(wav_file_dir, utt_id + ".wav")
             num_samples = np.random.randint(max_samples)
             signal = np.random.randint(
-                -(2 ** 15), 2 ** 15 - 1, num_samples, dtype=np.int16
+                -(2**15), 2**15 - 1, num_samples, dtype=np.int16
             )
             wv = wave.open(wav_path, "wb")
             wv.setnchannels(1)
@@ -69,7 +86,7 @@ def test_compute_feats_from_kaldi_tables(temp_dir):
             assert np.allclose(act, exp)
 
 
-def test_signals_to_torch_feat_dir(temp_dir):
+def test_signals_to_torch_feat_dir(temp_dir, config_type):
     torch = pytest.importorskip("torch")
     torch.manual_seed(50)
     feat_dir = os.path.join(temp_dir, "feat")
@@ -77,7 +94,7 @@ def test_signals_to_torch_feat_dir(temp_dir):
     map_path = os.path.join(temp_dir, "map")
     manifest_path = os.path.join(temp_dir, "manifest.txt")
     computer_json_path = os.path.join(
-        os.path.dirname(os.path.realpath(__file__)), "data", "fbank.json"
+        os.path.dirname(os.path.realpath(__file__)), "data", f"fbank.{config_type}"
     )
     preprocessor_json_path = os.path.join(temp_dir, "preprocess.json")
     with open(preprocessor_json_path, "w") as f:
@@ -96,7 +113,7 @@ def test_signals_to_torch_feat_dir(temp_dir):
             utt_ids.append(utt_id)
             num_samples = torch.randint(1, max_samples, (1,)).long().item()
             signal = torch.randint(
-                -(2 ** 15), 2 ** 15 - 1, (num_samples,), dtype=torch.float32
+                -(2**15), 2**15 - 1, (num_samples,), dtype=torch.float32
             )
             utt2signal[utt_id] = signal
             file_type = torch.randint(3, (1,)).long().item()

--- a/tox.ini
+++ b/tox.ini
@@ -4,17 +4,17 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py3{7,8,9,10,11,12}-{ruamel,pyyaml}
+envlist = py3{7,8,9,10,11,12}
 isolated_build = True
 
 [gh]
 python =
-    3.7 = py37-pyyaml, py37-ruamel
-    3.8 = py38-ruamel
-    3.9 = py39-ruamel
-    3.10 = py310-ruamel
-    3.11 = py311-ruamel
-    3.12 = py312-ruamel, py312-ruamel
+    3.7 = py37
+    3.8 = py38
+    3.9 = py39
+    3.10 = py310
+    3.11 = py311
+    3.12 = py312
 
 [testenv]
 install_command = pip install --find-links https://download.pytorch.org/whl/cpu/torch_stable.html {opts} {packages}
@@ -26,8 +26,7 @@ deps =
     pydrobert-kaldi
     webdataset
     h5py
-    ruamel: ruamel.yaml>=0.15
-    pyyaml: pyyaml
+    ruamel.yaml>=0.15
     
 commands =
     compute-feats-from-kaldi-tables --help

--- a/tox.ini
+++ b/tox.ini
@@ -4,8 +4,17 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py3{7,8,9,10,11,12}
+envlist = py3{7,8,9,10,11,12}-{ruamel,pyyaml}
 isolated_build = True
+
+[gh]
+python =
+    3.7 = py37-pyyaml, py37-ruamel
+    3.8 = py38-ruamel
+    3.9 = py39-ruamel
+    3.10 = py310-ruamel
+    3.11 = py311-ruamel
+    3.12 = py312-ruamel, py312-ruamel
 
 [testenv]
 install_command = pip install --find-links https://download.pytorch.org/whl/cpu/torch_stable.html {opts} {packages}
@@ -17,6 +26,8 @@ deps =
     pydrobert-kaldi
     webdataset
     h5py
+    ruamel: ruamel.yaml>=0.15
+    pyyaml: pyyaml
     
 commands =
     compute-feats-from-kaldi-tables --help


### PR DESCRIPTION
This PR silently switches the JSON parser to a YAML parser if [ruamel.yaml](https://yaml.readthedocs.io/en/latest/) is installed. This gives the end user the option to configure via JSON or the more-human-readable YAML.

JSON can nearly be parsed as YAML 1.1, except for some [corner cases](https://hitchdev.com/strictyaml/why/implicit-typing-removed/). Those cases were fixed in YAML 1.2, but [Pyyaml doesn't support 1.2](https://github.com/yaml/pyyaml), and certainly not by default, whereas `ruamel.yaml` does and is. The user can opt in to earlier versions of YAML with the header

``` yaml
%YAML 1.1
```

but, because it's not valid JSON, it's not going to break anything.

## Changelog
- CLI now quietly reads configs as YAML 1.2 via
  [ruamel.yaml](https://yaml.readthedocs.io/en/latest/) if installed. As JSON
  is valid YAML 1.2, it shouldn't break anything.